### PR TITLE
Fix Winter Crops disappearing in Winter

### DIFF
--- a/SpaceCore/Patches/HoeDirtPatcher.cs
+++ b/SpaceCore/Patches/HoeDirtPatcher.cs
@@ -44,13 +44,16 @@ namespace SpaceCore.Patches
                     && (insn.operand as MethodInfo).Name == "destroyCrop"
                     )
                 {
-                    Log.trace("Replacing destroyCrop with our call");
-                    // Replace with our call. We do this instead of nop to clear the stack entries
-                    // Because I'm too lazy to figure out the rest properly.
-                    insn.operand = PatchHelper.RequireMethod<HoeDirtPatcher>(nameof(DestroyCropReplacement));
+                    Log.trace("Removing destroyCrop call");
+                    // There are 4 items loaded to the stack at this point
+                    var pop = new CodeInstruction(OpCodes.Pop);
+                    newInsns.Add(pop.Clone());
+                    newInsns.Add(pop.Clone());
+                    newInsns.Add(pop.Clone());
+                    newInsns.Add(pop.Clone());
                     happened = true;
+                    continue;
                 }
-
                 newInsns.Add(insn);
             }
 
@@ -58,12 +61,6 @@ namespace SpaceCore.Patches
                 Log.error($"{nameof(Transpile_DayUpdate)} patching failed!");
                 }
             return newInsns;
-        }
-
-        private static void DestroyCropReplacement(HoeDirt hoeDirt, Vector2 tileLocation, bool showAnimation, GameLocation location)
-        {
-            // We don't want it to ever do anything.
-            // Crops wither out of season anyways.
         }
     }
 }

--- a/SpaceCore/Patches/SaveGamePatcher.cs
+++ b/SpaceCore/Patches/SaveGamePatcher.cs
@@ -105,7 +105,7 @@ namespace SpaceCore.Patches
             }
             if (ret.Count != 2)
             {
-                Log.warn($"Found {ret.Count} transpiler targets, expected 2");
+                Log.warn($"{nameof(GetLoadEnumeratorMethods)}: Found {ret.Count} transpiler targets, expected 2");
                 foreach (var meth in ret)
                 {
                     Log.trace("\t" + meth.Name + " " + meth);
@@ -129,7 +129,7 @@ namespace SpaceCore.Patches
             }
             if (ret.Count != 1)
             {
-                Log.warn($"Found {ret.Count} transpiler targets, expected 1");
+                Log.warn($"{nameof(GetSaveEnumeratorMethods)}: Found {ret.Count} transpiler targets, expected 1");
                 foreach (var meth in ret)
                 {
                     Log.trace("\t" + meth.Name + " " + meth);

--- a/SpaceCore/SpaceCore.csproj
+++ b/SpaceCore/SpaceCore.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\SpaceSharedHarmony\SpaceSharedHarmony.projitems" Label="Shared" />
 
   <PropertyGroup>
-    <Version>1.5.7.2</Version>
+    <Version>1.5.6</Version>
     <TargetFramework>net452</TargetFramework>
 
     <EnableHarmony>true</EnableHarmony>

--- a/SpaceCore/SpaceCore.csproj
+++ b/SpaceCore/SpaceCore.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\SpaceSharedHarmony\SpaceSharedHarmony.projitems" Label="Shared" />
 
   <PropertyGroup>
-    <Version>1.3.5</Version>
+    <Version>1.5.7.1</Version>
     <TargetFramework>net452</TargetFramework>
 
     <EnableHarmony>true</EnableHarmony>

--- a/SpaceCore/SpaceCore.csproj
+++ b/SpaceCore/SpaceCore.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\SpaceSharedHarmony\SpaceSharedHarmony.projitems" Label="Shared" />
 
   <PropertyGroup>
-    <Version>1.5.7.1</Version>
+    <Version>1.5.7.2</Version>
     <TargetFramework>net452</TargetFramework>
 
     <EnableHarmony>true</EnableHarmony>

--- a/SpaceCore/manifest.json
+++ b/SpaceCore/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
     "Name": "SpaceCore",
     "Author": "spacechase0",
-    "Version": "1.5.6",
+    "Version": "1.5.7-unofficial.1-pepoluan",
     "Description": "A framework mod used by some of my other mods.",
     "UniqueID": "spacechase0.SpaceCore",
     "EntryDll": "SpaceCore.dll",

--- a/SpaceCore/manifest.json
+++ b/SpaceCore/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
     "Name": "SpaceCore",
     "Author": "spacechase0",
-    "Version": "1.5.7-unofficial.1-pepoluan",
+    "Version": "1.5.7-unofficial.2-pepoluan",
     "Description": "A framework mod used by some of my other mods.",
     "UniqueID": "spacechase0.SpaceCore",
     "EntryDll": "SpaceCore.dll",

--- a/SpaceCore/manifest.json
+++ b/SpaceCore/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
     "Name": "SpaceCore",
     "Author": "spacechase0",
-    "Version": "1.5.7-unofficial.2-pepoluan",
+    "Version": "1.5.6",
     "Description": "A framework mod used by some of my other mods.",
     "UniqueID": "spacechase0.SpaceCore",
     "EntryDll": "SpaceCore.dll",


### PR DESCRIPTION
The issue was caused by SDV64-Win using `callvirt` instead of `call` to invoke `destroyCrop`.

The original code was hardcoded to look for `call` and does not have a "failure fuse", resulting in failing of patching to slip through the cracks.

I fixed this issue by looking for _both_ `callvirt` and `call`, plus adding a "fuse" to quickly pinpoint failure location.

Also in this PR:
* More informative logging message for unexpected transpiler count
* Bump Version
