### PR TITLE
Make 'var' usage not an error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -39,7 +39,7 @@ dotnet_style_predefined_type_for_locals_parameters_members = true:error
 dotnet_style_predefined_type_for_member_access = true:error
 
 # don't use 'var' for language keywords
-csharp_style_var_for_built_in_types = false:error
+csharp_style_var_for_built_in_types =false:suggestion
 
 # suggest modern C# features where simpler
 dotnet_style_object_initializer = true:suggestion


### PR DESCRIPTION
It's very annoying to see every single usage of `var` for predefined types (`string`, `int`, etc) marked as error.

Messes up the Build Report with false alarms.

Changing to `suggestion` will make them still highlighted/underlined, but no longer appearing as errors during build.
