### PR TITLE
[OTL] Fix Positioning + some configs

### DIFF
--- a/ObjectTimeLeft/Framework/Configuration.cs
+++ b/ObjectTimeLeft/Framework/Configuration.cs
@@ -5,5 +5,6 @@ namespace ObjectTimeLeft.Framework
     internal class Configuration
     {
         public SButton ToggleKey { get; set; } = SButton.L;
+        public float TextScale { get; set; } = 1.0f;
     }
 }

--- a/ObjectTimeLeft/Framework/Configuration.cs
+++ b/ObjectTimeLeft/Framework/Configuration.cs
@@ -6,5 +6,6 @@ namespace ObjectTimeLeft.Framework
     {
         public SButton ToggleKey { get; set; } = SButton.L;
         public float TextScale { get; set; } = 1.0f;
+        public bool ShowOnStart { get; set; } = true;
     }
 }

--- a/ObjectTimeLeft/Mod.cs
+++ b/ObjectTimeLeft/Mod.cs
@@ -1,12 +1,12 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-
 using ObjectTimeLeft.Framework;
 using SpaceShared;
 using SpaceShared.APIs;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
+using SObject = StardewValley.Object;
 
 namespace ObjectTimeLeft
 {
@@ -37,9 +37,9 @@ namespace ObjectTimeLeft
             if (capi != null)
             {
                 capi.RegisterModConfig(this.ModManifest, () => Mod.Config = new Configuration(), () => this.Helper.WriteConfig(Mod.Config));
-                capi.RegisterSimpleOption(this.ModManifest, "Show on Start", "Whether to start the game with time left already showing.", () => Mod.Config.ShowOnStart, (bool val) => Mod.Config.ShowOnStart = val);
-                capi.RegisterSimpleOption(this.ModManifest, "Key: Toggle Display", "The key to toggle the display on objects.", () => Mod.Config.ToggleKey, (SButton val) => Mod.Config.ToggleKey = val);
-                capi.RegisterSimpleOption(this.ModManifest, "Text Scale", "Scale of text that will superimpose the objects.", () => Mod.Config.TextScale, (float val) => Mod.Config.TextScale = val);
+                capi.RegisterSimpleOption(this.ModManifest, "Show on Start", "Whether to start the game with time left already showing.", () => Mod.Config.ShowOnStart, val => Mod.Config.ShowOnStart = val);
+                capi.RegisterSimpleOption(this.ModManifest, "Key: Toggle Display", "The key to toggle the display on objects.", () => Mod.Config.ToggleKey, val => Mod.Config.ToggleKey = val);
+                capi.RegisterSimpleOption(this.ModManifest, "Text Scale", "Scale of text that will superimpose the objects.", () => Mod.Config.TextScale, val => Mod.Config.TextScale = val);
             }
         }
 
@@ -60,68 +60,76 @@ namespace ObjectTimeLeft
             if (!this.Showing || !Context.IsPlayerFree)
                 return;
 
-            var sb = e.SpriteBatch;
-            Color half_blk = Color.Black * 0.5f;
+            Color shadowColor = Color.Black * 0.5f;
             float zoom = this.GetOptions().zoomLevel;
-            float text_scale = zoom * Mod.Config.TextScale;
+            float scale = zoom * Mod.Config.TextScale;
 
-            void DrawString(string str, Vector2 vec, Color clr)
+            void DrawString(string str, Vector2 position, Color color)
             {
-                sb.DrawString(
+                e.SpriteBatch.DrawString(
                     spriteFont: Game1.dialogueFont,
                     text: str,
-                    position: vec,
-                    color: clr,
+                    position: position,
+                    color: color,
                     rotation: 0.0f,
                     origin: Vector2.Zero,
-                    scale: text_scale,
+                    scale: scale,
                     effects: SpriteEffects.None,
                     layerDepth: 0.0f
-                    );
+                );
             }
 
-            Vector2 Adjust(Vector2 vec, float dx, float dy)
+            foreach (var pair in Game1.currentLocation.Objects.Pairs)
             {
-                return new Vector2(vec.X + (dx * zoom), vec.Y + (dy * zoom));
-            }
-
-            foreach (var entryKey in Game1.currentLocation.netObjects.Keys)
-            {
-                var obj = Game1.currentLocation.netObjects[entryKey];
-                if (obj.MinutesUntilReady <= 0 || obj.MinutesUntilReady == 999999 || obj.Name == "Stone")
+                SObject obj = pair.Value;
+                if (obj.MinutesUntilReady is <= 0 or 999999 || obj.Name == "Stone")
                     continue;
 
-                float x = entryKey.X * Game1.tileSize;
-                float y = entryKey.Y * Game1.tileSize;
-                Vector2 pos = Game1.GlobalToLocal(Game1.viewport, new Vector2(x, y));
-                x = pos.X;
-                y = pos.Y;
-                string str = (obj.MinutesUntilReady / 10).ToString();
-                float w = Game1.dialogueFont.MeasureString(str).X;
-                x += (Game1.tileSize - w) / 2;
+                string text = (obj.MinutesUntilReady / 10).ToString();
+                Vector2 pos = this.GetTimeLeftPosition(pair.Key, text, zoom);
 
-                Vector2 vec_xy = new Vector2(x, y) * zoom;
-
-                // Outline/shadow to make text contrasting
-                DrawString(str, Adjust(vec_xy,  0,  3), half_blk);
-                DrawString(str, Adjust(vec_xy,  3,  0), half_blk);
-                DrawString(str, Adjust(vec_xy,  0, -3), half_blk);
-                DrawString(str, Adjust(vec_xy, -3,  0), half_blk);
-                // Actual text itself
-                DrawString(str, vec_xy, Color.White);
+                // draw text outline for contrast
+                void DrawOutline(int offsetX, int offsetY)
+                {
+                    Vector2 shadowPos = new(pos.X + (offsetX * zoom), pos.Y + (offsetY * zoom));
+                    DrawString(text, shadowPos, shadowColor);
                 }
-            }
+                DrawOutline(0, 3);
+                DrawOutline(3, 0);
+                DrawOutline(0, -3);
+                DrawOutline(-3, 0);
 
+                // draw text
+                DrawString(text, pos, Color.White);
+            }
+        }
+
+        /// <summary>Get the position at which to draw the given text for a machine.</summary>
+        /// <param name="tile">The tile position containing the machine.</param>
+        /// <param name="text">The text to draw over the machine.</param>
+        /// <param name="zoom">The UI zoom to apply.</param>
+        private Vector2 GetTimeLeftPosition(Vector2 tile, string text, float zoom)
+        {
+            // get screen pixel position
+            Vector2 pos = Game1.GlobalToLocal(
+                Game1.viewport,
+                new Vector2(x: tile.X * Game1.tileSize, y: tile.Y * Game1.tileSize)
+            );
+
+            // center text over tile
+            float textWidth = Game1.dialogueFont.MeasureString(text).X;
+            pos.X += (Game1.tileSize - textWidth) / 2;
+
+            // apply zoom level
+            return pos * zoom;
+        }
+
+        /// <summary>Get the <see cref="Game1.options"/> property.</summary>
         private Options GetOptions()
         {
-            if (Constants.TargetPlatform == GamePlatform.Android)
-            {
-                return this.Helper.Reflection.GetField<Options>(typeof(Game1), "options").GetValue();
-            }
-            else
-            {
-                return Game1.game1.instanceOptions;  // using .game1.instanceOptions for split-screen-friendly (??)
-            }
+            return Constants.TargetPlatform == GamePlatform.Android
+                ? this.Helper.Reflection.GetField<Options>(typeof(Game1), "options").GetValue()
+                : Game1.options;
         }
     }
 }

--- a/ObjectTimeLeft/Mod.cs
+++ b/ObjectTimeLeft/Mod.cs
@@ -59,7 +59,9 @@ namespace ObjectTimeLeft
 
             var sb = e.SpriteBatch;
             Color half_blk = Color.Black * 0.5f;
-            float zoom = Game1.game1.instanceOptions.zoomLevel;
+            float zoom = Constants.TargetPlatform != GamePlatform.Android
+                ? Game1.game1.instanceOptions.zoomLevel  // this is for splitscreen (??)
+                : Game1.options.zoomLevel;
 
             void DrawString(string str, Vector2 vec, Color clr) {
                 sb.DrawString(

--- a/ObjectTimeLeft/Mod.cs
+++ b/ObjectTimeLeft/Mod.cs
@@ -56,6 +56,7 @@ namespace ObjectTimeLeft
                 return;
 
             var sb = e.SpriteBatch;
+            Color half_blk = Color.Black * 0.5f;
             foreach (var entryKey in Game1.currentLocation.netObjects.Keys)
             {
                 var obj = Game1.currentLocation.netObjects[entryKey];
@@ -72,14 +73,24 @@ namespace ObjectTimeLeft
                 float w = Game1.dialogueFont.MeasureString(str).X;
                 x += (Game1.tileSize - w) / 2;
 
-                sb.DrawString(Game1.dialogueFont, str, new Vector2(x + 0, y + 3), (Color.Black) * 0.5f);
-                sb.DrawString(Game1.dialogueFont, str, new Vector2(x + 3, y + 0), (Color.Black) * 0.5f);
-                sb.DrawString(Game1.dialogueFont, str, new Vector2(x + 0, y - 3), (Color.Black) * 0.5f);
-                sb.DrawString(Game1.dialogueFont, str, new Vector2(x - 3, y - 0), (Color.Black) * 0.5f);
-                sb.DrawString(Game1.dialogueFont, str, new Vector2(x, y), Color.White);
+                Vector2 vec_xy = new Vector2(x, y) * Game1.options.zoomLevel;
+
+                sb.DrawString(Game1.dialogueFont, str, vec_xy.Adjust( 0,  3), half_blk);
+                sb.DrawString(Game1.dialogueFont, str, vec_xy.Adjust( 3,  0), half_blk);
+                sb.DrawString(Game1.dialogueFont, str, vec_xy.Adjust( 0, -3), half_blk);
+                sb.DrawString(Game1.dialogueFont, str, vec_xy.Adjust(-3,  0), half_blk);
+                sb.DrawString(Game1.dialogueFont, str, vec_xy, Color.White);
                 //sb.Draw(Game1.mouseCursors, Game1.GlobalToLocal(Game1.viewport, new Vector2((float)(x * Game1.tileSize - 8), (float)(y * Game1.tileSize - Game1.tileSize * 3 / 2 - 16) + num)), new Microsoft.Xna.Framework.Rectangle?(new Microsoft.Xna.Framework.Rectangle(141, 465, 20, 24)), Color.White * 0.75f, 0.0f, Vector2.Zero, 4f, SpriteEffects.None, (float)((double)((y + 1) * Game1.tileSize) / 10000.0 + 9.99999997475243E-07 + (double)obj.tileLocation.X / 10000.0 + (obj.parentSheetIndex == 105 ? 0.00150000001303852 : 0.0)));
                 //StardewValley.BellsAndWhistles.SpriteText.drawString(sb, "" + obj.minutesUntilReady, (int)pos.X, (int)pos.Y);
+                }
             }
+    }
+
+    internal static class Vector2Extensions
+    {
+        internal static Vector2 Adjust(this Vector2 vec, float dx, float dy)
+        {
+            return new Vector2(vec.X + (dx * Game1.options.zoomLevel), vec.Y + (dy * Game1.options.zoomLevel));
         }
     }
 }

--- a/ObjectTimeLeft/Mod.cs
+++ b/ObjectTimeLeft/Mod.cs
@@ -63,12 +63,12 @@ namespace ObjectTimeLeft
                     continue;
 
                 //float num = (float)(4.0 * Math.Round(Math.Sin(DateTime.Now.TimeOfDay.TotalMilliseconds / 250.0), 2));
-                float x = entryKey.X;
-                float y = entryKey.Y;
-                Vector2 pos = Game1.GlobalToLocal(Game1.viewport, new Vector2(x * Game1.tileSize, y * Game1.tileSize));
+                float x = entryKey.X * Game1.tileSize;
+                float y = entryKey.Y * Game1.tileSize;
+                Vector2 pos = Game1.GlobalToLocal(Game1.viewport, new Vector2(x, y));
                 x = pos.X;
                 y = pos.Y;
-                string str = "" + obj.MinutesUntilReady / 10;
+                string str = (obj.MinutesUntilReady / 10).ToString();
                 float w = Game1.dialogueFont.MeasureString(str).X;
                 x += (Game1.tileSize - w) / 2;
 

--- a/ObjectTimeLeft/Mod.cs
+++ b/ObjectTimeLeft/Mod.cs
@@ -1,4 +1,6 @@
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
 using ObjectTimeLeft.Framework;
 using SpaceShared;
 using SpaceShared.APIs;
@@ -57,6 +59,22 @@ namespace ObjectTimeLeft
 
             var sb = e.SpriteBatch;
             Color half_blk = Color.Black * 0.5f;
+            float zoom = Game1.game1.instanceOptions.zoomLevel;
+
+            void DrawString(string str, Vector2 vec, Color clr) {
+                sb.DrawString(
+                    spriteFont: Game1.dialogueFont,
+                    text: str,
+                    position: vec,
+                    color: clr,
+                    rotation: 0.0f,
+                    origin: Vector2.Zero,
+                    scale: zoom,
+                    effects: SpriteEffects.None,
+                    layerDepth: 0.0f
+                    );
+                }
+
             foreach (var entryKey in Game1.currentLocation.netObjects.Keys)
             {
                 var obj = Game1.currentLocation.netObjects[entryKey];
@@ -73,13 +91,13 @@ namespace ObjectTimeLeft
                 float w = Game1.dialogueFont.MeasureString(str).X;
                 x += (Game1.tileSize - w) / 2;
 
-                Vector2 vec_xy = new Vector2(x, y) * Game1.options.zoomLevel;
+                Vector2 vec_xy = new Vector2(x, y) * zoom;
 
-                sb.DrawString(Game1.dialogueFont, str, vec_xy.Adjust( 0,  3), half_blk);
-                sb.DrawString(Game1.dialogueFont, str, vec_xy.Adjust( 3,  0), half_blk);
-                sb.DrawString(Game1.dialogueFont, str, vec_xy.Adjust( 0, -3), half_blk);
-                sb.DrawString(Game1.dialogueFont, str, vec_xy.Adjust(-3,  0), half_blk);
-                sb.DrawString(Game1.dialogueFont, str, vec_xy, Color.White);
+                DrawString(str, vec_xy.Adjust( 0,  3), half_blk);
+                DrawString(str, vec_xy.Adjust( 3,  0), half_blk);
+                DrawString(str, vec_xy.Adjust( 0, -3), half_blk);
+                DrawString(str, vec_xy.Adjust(-3,  0), half_blk);
+                DrawString(str, vec_xy, Color.White);
                 //sb.Draw(Game1.mouseCursors, Game1.GlobalToLocal(Game1.viewport, new Vector2((float)(x * Game1.tileSize - 8), (float)(y * Game1.tileSize - Game1.tileSize * 3 / 2 - 16) + num)), new Microsoft.Xna.Framework.Rectangle?(new Microsoft.Xna.Framework.Rectangle(141, 465, 20, 24)), Color.White * 0.75f, 0.0f, Vector2.Zero, 4f, SpriteEffects.None, (float)((double)((y + 1) * Game1.tileSize) / 10000.0 + 9.99999997475243E-07 + (double)obj.tileLocation.X / 10000.0 + (obj.parentSheetIndex == 105 ? 0.00150000001303852 : 0.0)));
                 //StardewValley.BellsAndWhistles.SpriteText.drawString(sb, "" + obj.minutesUntilReady, (int)pos.X, (int)pos.Y);
                 }

--- a/ObjectTimeLeft/Mod.cs
+++ b/ObjectTimeLeft/Mod.cs
@@ -37,6 +37,7 @@ namespace ObjectTimeLeft
             {
                 capi.RegisterModConfig(this.ModManifest, () => Mod.Config = new Configuration(), () => this.Helper.WriteConfig(Mod.Config));
                 capi.RegisterSimpleOption(this.ModManifest, "Key: Toggle Display", "The key to toggle the display on objects.", () => Mod.Config.ToggleKey, (SButton val) => Mod.Config.ToggleKey = val);
+                capi.RegisterSimpleOption(this.ModManifest, "Text Scale", "Scale of text that will superimpose the objects.", () => Mod.Config.TextScale, (float val) => Mod.Config.TextScale = val);
             }
         }
 

--- a/ObjectTimeLeft/Mod.cs
+++ b/ObjectTimeLeft/Mod.cs
@@ -60,8 +60,10 @@ namespace ObjectTimeLeft
             var sb = e.SpriteBatch;
             Color half_blk = Color.Black * 0.5f;
             float zoom = this.GetOptions().zoomLevel;
+            float text_scale = zoom * Mod.Config.TextScale;
 
-            void DrawString(string str, Vector2 vec, Color clr) {
+            void DrawString(string str, Vector2 vec, Color clr)
+            {
                 sb.DrawString(
                     spriteFont: Game1.dialogueFont,
                     text: str,
@@ -69,11 +71,11 @@ namespace ObjectTimeLeft
                     color: clr,
                     rotation: 0.0f,
                     origin: Vector2.Zero,
-                    scale: zoom,
+                    scale: text_scale,
                     effects: SpriteEffects.None,
                     layerDepth: 0.0f
                     );
-                }
+            }
 
             Vector2 Adjust(Vector2 vec, float dx, float dy)
             {

--- a/ObjectTimeLeft/Mod.cs
+++ b/ObjectTimeLeft/Mod.cs
@@ -15,7 +15,7 @@ namespace ObjectTimeLeft
         public static Mod Instance;
         public static Configuration Config;
 
-        private bool Showing = true;
+        private bool Showing;
 
         /// <summary>The mod entry point, called after the mod is first loaded.</summary>
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
@@ -24,6 +24,7 @@ namespace ObjectTimeLeft
             Mod.Instance = this;
             Log.Monitor = this.Monitor;
             Mod.Config = helper.ReadConfig<Configuration>();
+            this.Showing = Mod.Config.ShowOnStart;
 
             helper.Events.GameLoop.GameLaunched += this.OnGameLaunched;
             helper.Events.Display.RenderingHud += this.OnRenderingHud;
@@ -36,6 +37,7 @@ namespace ObjectTimeLeft
             if (capi != null)
             {
                 capi.RegisterModConfig(this.ModManifest, () => Mod.Config = new Configuration(), () => this.Helper.WriteConfig(Mod.Config));
+                capi.RegisterSimpleOption(this.ModManifest, "Show on Start", "Whether to start the game with time left already showing.", () => Mod.Config.ShowOnStart, (bool val) => Mod.Config.ShowOnStart = val);
                 capi.RegisterSimpleOption(this.ModManifest, "Key: Toggle Display", "The key to toggle the display on objects.", () => Mod.Config.ToggleKey, (SButton val) => Mod.Config.ToggleKey = val);
                 capi.RegisterSimpleOption(this.ModManifest, "Text Scale", "Scale of text that will superimpose the objects.", () => Mod.Config.TextScale, (float val) => Mod.Config.TextScale = val);
             }


### PR DESCRIPTION
Mod affected: **Object Time Left** ( `spacechase0.ObjectTimeLeft` )

This mainly fix the positioning of the "time left" overlay, which due to not considering `zoomLevel`, was drawn on the wrong spot on-screen.

Additional configs:
* Text scale option (if player thinks the "time left" overlay is too big, mostly)
* Show on start (whether to start the game with "time left" overlay already showing; defaults to `true` to maintain same behavior)
