### PR TITLE
Require holding cast button to switch spell bar

### DIFF
--- a/Magic/Framework/Magic.cs
+++ b/Magic/Framework/Magic.cs
@@ -382,9 +382,10 @@ namespace Magic.Framework
             if (Game1.activeClickableMenu != null)
                 return;
 
-            if (e.Button == Mod.Config.Key_SwapSpells)
+            if (Magic.CastPressed && e.Button == Mod.Config.Key_SwapSpells)
             {
                 Game1.player.GetSpellBook().SwapPreparedSet();
+                Magic.InputHelper.Suppress(e.Button);
             }
             else if (Magic.CastPressed &&
                      (e.Button == Mod.Config.Key_Spell1 || e.Button == Mod.Config.Key_Spell2 ||


### PR DESCRIPTION
When you press the default key for switching your magic bars (TAB), you also switch the inventory bars, and the magic bars are switched around even if you do not hold the magic key (default 'q') pressed, which is quite unexpected compared to the spell keys (1-5) and probably not intended.

While you can just change either key away from TAB, this pull request should fix the problem. Note that I cannot actually build this project because it cannot find the Tiled.net library, so no idea if this works, but I see no reason it wouldn't.