### PR TITLE
Catch OOM exception during game save and retry

### DIFF
--- a/SpaceCore/Patches/SaveGamePatcher.cs
+++ b/SpaceCore/Patches/SaveGamePatcher.cs
@@ -381,9 +381,9 @@ namespace SpaceCore.Patches
             {
                 Log.Warn("Ran out of memory while SpaceCore was attempting to save; trying again...");
 
-                GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
+                GC.Collect(GC.MaxGeneration);
                 GC.WaitForPendingFinalizers();
-                GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
+                GC.Collect(GC.MaxGeneration);
 
                 // If this fails again, let it do so.
                 doc.WriteContentTo(origWriter);


### PR DESCRIPTION
If SpaceCore throws an OutOfMemoryException during copy to origWriter, run GC and try again. Added benefit of potentially saving OOM exceptions during the remainder of the function.

This is a workaround for decreasing the likelihood of failed saves on 32-bit Stardew installs.

The PR targets `main` since `develop` has moved on to developing for `1.5.5`. This will hopefully help folks who run into issues while running `1.5.4`.