### PR TITLE
[DGA ]Furniture draw fixes and placement fixes

### DIFF
--- a/DynamicGameAssets/DynamicGameAssets.csproj
+++ b/DynamicGameAssets/DynamicGameAssets.csproj
@@ -7,8 +7,6 @@
     <Version>1.2.1</Version>
     <TargetFramework>net452</TargetFramework>
     <EnableHarmony>true</EnableHarmony>
-	<GameModsPath>C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\fishtest</GameModsPath>
-	
   </PropertyGroup>
 
   <ItemGroup>

--- a/DynamicGameAssets/DynamicGameAssets.csproj
+++ b/DynamicGameAssets/DynamicGameAssets.csproj
@@ -7,6 +7,8 @@
     <Version>1.2.1</Version>
     <TargetFramework>net452</TargetFramework>
     <EnableHarmony>true</EnableHarmony>
+	<GameModsPath>C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\fishtest</GameModsPath>
+	
   </PropertyGroup>
 
   <ItemGroup>

--- a/DynamicGameAssets/Game/CustomBasicFurniture.cs
+++ b/DynamicGameAssets/Game/CustomBasicFurniture.cs
@@ -106,8 +106,17 @@ namespace DynamicGameAssets.Game
                 }
                 else
                 {
-                    spriteBatch.Draw(Game1.shadowTexture, Game1.GlobalToLocal(Game1.viewport, new Vector2(this.boundingBox.Center.X - 32, this.boundingBox.Center.Y - (this.drawHeldObjectLow ? 32 : 85))) + new Vector2(32f, 53f), Game1.shadowTexture.Bounds, Color.White * alpha, 0f, new Vector2(Game1.shadowTexture.Bounds.Center.X, Game1.shadowTexture.Bounds.Center.Y), 4f, SpriteEffects.None, (float)this.boundingBox.Bottom / 10000f);
-                    spriteBatch.Draw(Game1.objectSpriteSheet, Game1.GlobalToLocal(Game1.viewport, new Vector2(this.boundingBox.Center.X - 32, this.boundingBox.Center.Y - (this.drawHeldObjectLow ? 32 : 85))), GameLocation.getSourceRectForObject(this.heldObject.Value.ParentSheetIndex), Color.White * alpha, 0f, Vector2.Zero, 4f, SpriteEffects.None, (float)(this.boundingBox.Bottom + 1) / 10000f);
+                    spriteBatch.Draw(Game1.shadowTexture, Game1.GlobalToLocal(Game1.viewport, new Vector2(this.boundingBox.Center.X - 32, this.boundingBox.Center.Y - (this.drawHeldObjectLow.Value ? 32 : 85))) + new Vector2(32f, 53f), Game1.shadowTexture.Bounds, Color.White * alpha, 0f, new Vector2(Game1.shadowTexture.Bounds.Center.X, Game1.shadowTexture.Bounds.Center.Y), 4f, SpriteEffects.None, (float)this.boundingBox.Bottom / 10000f);
+                    if(this.heldObject.Value is CustomObject customObject)
+                    {
+                        Vector2 position = new Vector2(this.boundingBox.Center.X - 32, this.boundingBox.Center.Y - (this.drawHeldObjectLow.Value ? 32 : 85));
+                        customObject.draw(spriteBatch, (int)position.X, (int)position.Y, (float)(this.boundingBox.Bottom + 1) / 10000f + 0.5f, alpha);
+                    }
+                    else
+                    {
+                        spriteBatch.Draw(Game1.objectSpriteSheet, Game1.GlobalToLocal(Game1.viewport, new Vector2(this.boundingBox.Center.X - 32, this.boundingBox.Center.Y - (this.drawHeldObjectLow.Value ? 32 : 85))), GameLocation.getSourceRectForObject(this.heldObject.Value.ParentSheetIndex), Color.White * alpha, 0f, Vector2.Zero, 4f, SpriteEffects.None, (float)(this.boundingBox.Bottom + 1) / 10000f);
+
+                    }
                 }
             }
             if ((bool)this.isOn && (int)this.furniture_type == 14)

--- a/DynamicGameAssets/Game/CustomBasicFurniture.cs
+++ b/DynamicGameAssets/Game/CustomBasicFurniture.cs
@@ -110,7 +110,7 @@ namespace DynamicGameAssets.Game
                     if(this.heldObject.Value is CustomObject customObject)
                     {
                         Vector2 position = new Vector2(this.boundingBox.Center.X - 32, this.boundingBox.Center.Y - (this.drawHeldObjectLow.Value ? 32 : 85));
-                        customObject.draw(spriteBatch, (int)position.X, (int)position.Y, (float)(this.boundingBox.Bottom + 1) / 10000f + 0.5f, alpha);
+                        customObject.draw(spriteBatch, (int)position.X, (int)position.Y, (float)(this.boundingBox.Bottom + 1) / 10000f, alpha);
                     }
                     else
                     {

--- a/DynamicGameAssets/Game/CustomObject.cs
+++ b/DynamicGameAssets/Game/CustomObject.cs
@@ -298,6 +298,20 @@ namespace DynamicGameAssets.Game
 
         public override bool canBePlacedHere(GameLocation l, Vector2 tile)
         {
+            Vector2 nonTile = tile * 64f * 64f;
+            nonTile.X += 32f;
+            nonTile.Y += 32f;
+            foreach (Furniture f in l.furniture)
+            {
+                if ((int)f.furniture_type.Value == 11 && f.getBoundingBox(f.TileLocation).Contains((int)nonTile.X, (int)nonTile.Y) && f.heldObject.Value == null)
+                {
+                    return true;
+                }
+                if (f.getBoundingBox(f.TileLocation).Intersects(new Rectangle((int)tile.X * 64, (int)tile.Y * 64, 64, 64)) && !f.isPassable() && !f.AllowPlacementOnThisTile((int)tile.X, (int)tile.Y))
+                {
+                    return false;
+                }
+            }
             return this.isPlaceable() && !l.isTileOccupiedForPlacement(tile, this);
         }
 

--- a/DynamicGameAssets/Patches/FurniturePatcher.cs
+++ b/DynamicGameAssets/Patches/FurniturePatcher.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using DynamicGameAssets.Game;
 using HarmonyLib;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Spacechase.Shared.Patching;
 using SpaceShared;
 using StardewModdingAPI;
@@ -25,6 +27,10 @@ namespace DynamicGameAssets.Patches
             harmony.Patch(
                 original: this.RequireMethod<Furniture>(nameof(Furniture.updateRotation)),
                 prefix: this.GetHarmonyMethod(nameof(Before_UpdateRotation))
+            );
+            harmony.Patch(
+                original: this.RequireMethod<Furniture>(nameof(Furniture.drawAtNonTileSpot)),
+                prefix: this.GetHarmonyMethod(nameof(Before_drawAtNonTileSpot))
             );
         }
 
@@ -56,6 +62,17 @@ namespace DynamicGameAssets.Patches
             if (__instance is CustomBasicFurniture furniture)
             {
                 furniture.UpdateRotation();
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool Before_drawAtNonTileSpot(Furniture __instance, SpriteBatch spriteBatch, Vector2 location, float layerDepth, float alpha)
+        {
+            if (__instance is CustomBasicFurniture furniture)
+            {
+                furniture.drawAtNonTileSpot(spriteBatch, location, layerDepth, alpha);
                 return false;
             }
 


### PR DESCRIPTION
Fixes issue that CustomObjects could be placed on a tile covered by furniture (Vanilla or DGA furniture).
Fixes issue that CustomObjects are not drawn correctly on top of DGA tables.
Fixes issue that DGA Furniture wasnt drawn correctly on top of DGA or Vanilla tables (was drawn as random vanilla chair instead)

Does **not** fix the issue of CustomObjects not being drawn correctly on Vanilla tables, this needs a transpiler fix for `Furniture.draw()`. (or it could be solved by postfixing `Furniture.draw()`, but the base function would still draw the (inexistent) object with ID 1720 from springobjects, which might led to future issues?)
