### PR TITLE
Allow creating colored items through the DGA API, fix error when item ID is invalid

### DIFF
--- a/DynamicGameAssets/Api.cs
+++ b/DynamicGameAssets/Api.cs
@@ -1,4 +1,5 @@
 using DynamicGameAssets.Game;
+using Microsoft.Xna.Framework;
 using StardewModdingAPI;
 
 namespace DynamicGameAssets
@@ -15,9 +16,20 @@ namespace DynamicGameAssets
         }
 
         /// <inheritdoc/>
+        public object SpawnDGAItem(string fullId, Color? color)
+        {
+            object spawnDgaItem = this.SpawnDGAItem(fullId);
+            if(color.HasValue && spawnDgaItem is CustomObject obj)
+            {
+                obj.ObjectColor = color;
+            }
+            return spawnDgaItem;
+        }
+
+        /// <inheritdoc/>
         public object SpawnDGAItem(string fullId)
         {
-            return Mod.Find(fullId).ToItem();
+            return Mod.Find(fullId)?.ToItem();
         }
 
         /// <inheritdoc/>

--- a/DynamicGameAssets/IDynamicGameAssetsApi.cs
+++ b/DynamicGameAssets/IDynamicGameAssetsApi.cs
@@ -1,3 +1,4 @@
+using Microsoft.Xna.Framework;
 using StardewModdingAPI;
 
 namespace DynamicGameAssets
@@ -10,6 +11,15 @@ namespace DynamicGameAssets
         /// <param name="item">The item to get the DGA item ID of.</param>
         /// <returns>The DGA item ID if it has one, otherwise null.</returns>
         string GetDGAItemId(object item);
+
+        /// <summary>
+        /// Spawn a DGA item, referenced with its full ID ("mod.id/ItemId").
+        /// Some items, such as crafting recipes or crops, don't have an item representation.
+        /// </summary>
+        /// <param name="fullId">The full ID of the item to spawn.</param>
+        /// <param name="color">The color of the item.</param>
+        /// <returns></returns>
+        object SpawnDGAItem(string fullId, Color? color);
 
         /// <summary>
         /// Spawn a DGA item, referenced with its full ID ("mod.id/ItemId").

--- a/DynamicGameAssets/Mod.cs
+++ b/DynamicGameAssets/Mod.cs
@@ -91,6 +91,7 @@ namespace DynamicGameAssets
         public static CommonPackData Find(string fullId)
         {
             int slash = fullId.IndexOf('/');
+            if (slash < 0) return null;
             string pack = fullId.Substring(0, slash);
             string item = fullId.Substring(slash + 1);
             return Mod.contentPacks.ContainsKey(pack) ? Mod.contentPacks[pack].Find(item) : null;


### PR DESCRIPTION
- Make it possible to create colored objects.
- Protect code from exceptions when the full ID is invalid.