### PR TITLE
Fix DGA custom forge recipe errors

### DIFF
--- a/DynamicGameAssets/DGACustomForgeRecipe.cs
+++ b/DynamicGameAssets/DGACustomForgeRecipe.cs
@@ -32,8 +32,6 @@ namespace DynamicGameAssets
                         item = null;
                     else
                         item.Stack -= left;
-
-                    left -= item.Stack;
                 }
             }
 

--- a/SpaceCore/Interface/NewForgeMenu.cs
+++ b/SpaceCore/Interface/NewForgeMenu.cs
@@ -711,6 +711,7 @@ namespace SpaceCore.Interface
             {
                 this._craftState = CraftState.Valid;
                 Item left_item_clone = left_item.getOne();
+                left_item_clone.Stack = left_item.Stack;
                 if (right_item != null && Utility.IsNormalObjectAtParentSheetIndex(right_item, 72))
                 {
                     (left_item_clone as Tool).AddEnchantment(new DiamondEnchantment());
@@ -718,7 +719,9 @@ namespace SpaceCore.Interface
                 }
                 else
                 {
-                    this.craftResultDisplay.item = this.CraftItem(left_item_clone, right_item.getOne());
+                    Item right_item_clone = right_item.getOne();
+                    right_item_clone.Stack = right_item.Stack;
+                    this.craftResultDisplay.item = this.CraftItem(left_item_clone, right_item_clone);
                 }
             }
             else


### PR DESCRIPTION
I noticed a few errors while testing DGA's custom forge recipes:

**1.** A null reference exception occurs whenever the base item or ingredient are expended (i.e. their stack size is not greater than what the recipe requires): https://smapi.io/log/5e3326cfa57749f4ad5f71bf079e86e4

This PR removes an obsolete `Item.Stack` check after the item is removed.

**2.** If the base item or ingredient of a custom forge recipe requires more than 1 of the item ("Quantity" setting > 1), the forge menu displays the base item in place of the recipe's actual result.

This PR adds a `Item.Stack` copying to the ingredient cloning in SpaceCore's `NewForgeMenu._ValidateCraft()`, which lets it simulate the correct result.

(PS: The JSON parsing error in that log is apparently caused by loading DGA's example pack without GMCM installed. I couldn't track that one down, and it seems unrelated to the other issues.)