### PR TITLE
GMCM: Fix calculation of rows occupied by multi-row options

### DIFF
--- a/GenericModConfigMenu/Framework/SpecificModConfigMenu.cs
+++ b/GenericModConfigMenu/Framework/SpecificModConfigMenu.cs
@@ -322,7 +322,7 @@ namespace GenericModConfigMenu.Framework
                 // add spacer rows for multi-row content
                 {
                     int elementHeight = new[] { label?.Height, optionElement?.Height, rightLabel?.Height }.Max(p => p ?? 0);
-                    float overlapRows = ((elementHeight * 1.0f) / (this.Table.RowHeight + 16)) - 1;
+                    float overlapRows = ((elementHeight * 1.0f) / this.Table.RowHeight) - 1;
 
                     if (overlapRows > 0.05f) // avoid adding an empty row if an element only overlaps slightly
                     {

--- a/GenericModConfigMenu/docs/release-notes.md
+++ b/GenericModConfigMenu/docs/release-notes.md
@@ -2,6 +2,7 @@
 
 # Release notes
 ## Upcoming release
+* Fixed calculation of rows occupied by multi-row options.
 * Fixed mouse-wheel-scroll sound playing even after the menu is closed.
 * Fixed API `TryGetCurrentMenu` method not working when on the title screen.
 * Improved translations. Thanks to BuslaevLegat (added Russian)!


### PR DESCRIPTION
The code in GMCM `SpecificModConfigMenu` to calculate the number of rows occupied by an option adds `16` to the table's `RowHeight`, presumably to account for the row padding added by `Table`.  However, the setter for `RowHeight` already [adds](https://github.com/spacechase0/StardewValleyMods/blob/9556ae1d04fe5b6e292d1bf303b6bdb74a911ea8/SpaceShared/UI/Table.cs#L41) the padding.  This can result in the calculation thinking an option occupied fewer rows than it actually does (resulting in the next option partially overlapping).

To reproduce this problem:
1. install [GMCM Options](https://github.com/jltaylor-us/StardewGMCMOptions/releases/tag/v1.0.0-beta.1)
2. Run SDV and enter `gmcmoptions-example` in the console
3. Open the GMCM menu for GMCM Options.  Observe that the second option overlaps the first.