### PR TITLE
Fix table rendering of partially visible elements

### DIFF
--- a/GenericModConfigMenu/docs/release-notes.md
+++ b/GenericModConfigMenu/docs/release-notes.md
@@ -2,6 +2,9 @@
 
 # Release notes
 ## Upcoming release
+* Options now render when they are partially visibile at the top of the menu.
+  (This means multi-row options no longer disappear and leave blank rows as
+  as they scroll off the top of the menu.)
 * Fixed mouse-wheel-scroll sound playing even after the menu is closed.
 * Fixed API `TryGetCurrentMenu` method not working when on the title screen.
 * Improved translations. Thanks to BuslaevLegat (added Russian)!

--- a/SpaceShared/UI/Table.cs
+++ b/SpaceShared/UI/Table.cs
@@ -91,7 +91,7 @@ namespace SpaceShared.UI
                 {
                     element.LocalPosition = new Vector2(element.LocalPosition.X, ir * this.RowHeight - this.Scrollbar.TopRow * this.RowHeight);
                     if (element is not Label && // Labels must update anyway to get rid of hovertext on scrollwheel
-                            (element.Position.Y < this.Position.Y || element.Position.Y + this.RowHeight - Table.RowPadding > this.Position.Y + this.Size.Y))
+                            ElementIsOffscreen(element))
                         continue;
                     element.Update();
                 }
@@ -108,7 +108,7 @@ namespace SpaceShared.UI
                 foreach (var element in row)
                 {
                     element.LocalPosition = new Vector2(element.LocalPosition.X, ir * this.RowHeight - this.Scrollbar.ScrollPercent * this.Rows.Count * this.RowHeight);
-                    element.Update(isOffScreen || element.Position.Y < this.Position.Y || element.Position.Y + this.RowHeight - Table.RowPadding > this.Position.Y + this.Size.Y);
+                    element.Update(isOffScreen || ElementIsOffscreen(element));
                 }
                 ++ir;
             }
@@ -138,7 +138,7 @@ namespace SpaceShared.UI
                 {
                     foreach (var element in row)
                     {
-                        if (element.Position.Y < this.Position.Y || element.Position.Y + this.RowHeight - Table.RowPadding > this.Position.Y + this.Size.Y)
+                        if (ElementIsOffscreen(element))
                             continue;
                         if (element == this.RenderLast)
                             continue;
@@ -156,6 +156,10 @@ namespace SpaceShared.UI
         /*********
         ** Private methods
         *********/
+        private bool ElementIsOffscreen(Element element) {
+            return element.Position.Y + element.Height < this.Position.Y || element.Position.Y + this.RowHeight - Table.RowPadding > this.Position.Y + this.Size.Y;
+        }
+
         private void UpdateScrollbar()
         {
             this.Scrollbar.LocalPosition = new Vector2(this.Size.X + 48, this.Scrollbar.LocalPosition.Y);


### PR DESCRIPTION
Table rows now render if the bottom (rather than top) pixel is low enough
to be within the current scroll area.  The practical result is that
multi-row GMCM options will no longer disappear and leave blank rows as
the scroll off the top of the menu.

Example behavior of a multi-row GMCM option before this fix:

https://user-images.githubusercontent.com/18684406/147978656-f6c37db8-622f-4240-aba9-e93a15564418.mov


Example behavior after:

https://user-images.githubusercontent.com/18684406/147978660-1c569159-4f49-472f-b711-721bf8522bad.mov

_note:_ Need to merge with 69fdc18 and check that the resulting behavior is the desired behavior.
