### PR TITLE
Fix Krobus shop

### DIFF
--- a/DynamicGameAssets/Patches/Shops.cs
+++ b/DynamicGameAssets/Patches/Shops.cs
@@ -68,7 +68,7 @@ namespace DynamicGameAssets.Patches
 
             // sewer
             harmony.Patch(
-                original: this.RequireMethod<Sewer>("generateKrobusStock"),
+                original: this.RequireMethod<Sewer>(nameof(Sewer.getShadowShopStock)),
                 postfix: this.GetHarmonyMethod(nameof(After_Sewer_GenerateKrobusStock))
             );
 


### PR DESCRIPTION
Right now Krobus shop stock throws an error because the shop stock is being added midway through the base game generating shop stock. Adding DGA stock at the end allows the synchronization to happen without any DGA items in the shop stock, eliminating the error. Basically, it's just postfixing the 2nd Krobus shop stock function instead of the first one. 