### PR TITLE
Krobus shop fix

### DIFF
--- a/DynamicGameAssets/Patches/Shops.cs
+++ b/DynamicGameAssets/Patches/Shops.cs
@@ -68,7 +68,7 @@ namespace DynamicGameAssets.Patches
 
             // sewer
             harmony.Patch(
-                original: this.RequireMethod<Sewer>("generateKrobusStock"),
+                original: this.RequireMethod<Sewer>(nameof(Sewer.getShadowShopStock)),
                 postfix: this.GetHarmonyMethod(nameof(After_Sewer_GenerateKrobusStock))
             );
 


### PR DESCRIPTION
Take number two, here's some info:

All the other synchronized shops synchronize before DGA adds shop items, because DGA is using postfixing
But since Krobus stock is generated in two different functions
and DGA is postfixing the first one
The synchronization is happening after DGA stock is added
And therefore errors are happening