### PR TITLE
Numerous changes to Better Shop Menu

### DIFF
--- a/BetterShopMenu/BetterShopMenu.csproj
+++ b/BetterShopMenu/BetterShopMenu.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <Version>1.3.4</Version>
     <TargetFramework>net5.0</TargetFramework>
+    <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BetterShopMenu/Mod.cs
+++ b/BetterShopMenu/Mod.cs
@@ -214,6 +214,8 @@ namespace BetterShopMenu
             var items = new List<ISalable>();
             var stock = new Dictionary<ISalable, int[]>();
 
+            this.Shop.currentItemIndex = 0;
+
             int curCat = this.CurrCategory;
             int sCat = 0;
             bool inSeason = true;

--- a/BetterShopMenu/i18n/default.json
+++ b/BetterShopMenu/i18n/default.json
@@ -56,6 +56,6 @@
     /*********
     ** Generic Mod Config Menu UI
     *********/
-    "config.grid-layout.name": "Experimental Grid Layout",
-    "config.grid-layout.tooltip": "Whether to use the experimental grid layout in shops. This may cause minor display issues or impact other mods' features in shop menus."
+    "config.grid-layout.name": "Grid Layout",
+    "config.grid-layout.tooltip": "Whether to use the grid layout in shops. This may impact other mods' features in shop menus."
 }

--- a/BetterShopMenu/i18n/es.json
+++ b/BetterShopMenu/i18n/es.json
@@ -55,6 +55,6 @@
     /*********
     ** Generic Mod Config Menu UI
     *********/
-    "config.grid-layout.name": "Disposición experimental de cuadrícula",
-    "config.grid-layout.tooltip": "Si se utiliza el diseño experimental de la rejilla en las tiendas. Esto puede causar pequeños problemas de visualización o afectar a las características de otros mods en los menús de las tiendas."
+    "config.grid-layout.name": "Disposición de cuadrícula",
+    "config.grid-layout.tooltip": "Si se utiliza el diseño de la rejilla en las tiendas. Esto puede afectar a las características de otros mods en los menús de las tiendas."
 }


### PR DESCRIPTION
A lot of changes here so this will be wordy. Changes are purely for grid layout.

There is a bugfix to my previous BSM PR with the seeds filter addition/changes. Fix related to recipes. (line 260)

1/5/25 purchase increments just like SDV 1.5.5. Ctrl+Shift+click for 25 purchase.

Bigger backpack mod is supported.

Right click (hold) repeat purchase mode like vanilla has been added. This required a Harmony Prefix path to remove the ShopMenu right click code. SMAPI input suppression causes an immediate mouse up and thus we lose the ability to detect a hold. We no longer suppress right click but patch out the underlying ShopMenu code. I may want to do more tweaking here.

Scroll bars function properly and the thumb is accurate to position. This required a Harmony Prefix patch to remove the ShopMenu mouse wheel code.

No visual artifacts from ShopMenu hover text under our hover text. This required a Harmony Prefix patch to patch out the ShopMenu.,draw code. As such I copied of the ShopMenu.draw code to the grid layout draw. The mod draw is no longer partially dependent on the underlying ShopMenu drawing.

This is a Norman thing, but I changed the event hooking to only hook into necessary events when a Shop menu is activated. Having stuff called 60/s when it will never do anything is just something that bothers me so I changed it since we do have a clear event which provides an easy point to hook/unhook. Menus are so rarely active when playing the game.

There are also a bunch of other refactors. Values defined global that were default locally more than once. Sequential ifs that were exclusive are now if..else if sequences. I moved some procedures around, closer to where I was working. This made it easier to bounce(view) from proc/to proc as I was learning SDV UI type stuff (first time for me) and the mods actions. As I was trying to understand the code I made changes like this. They really did not change function. I mention this since they can make viewing a Git difference difficult.

I edited the i18n items for GMCM (default and es). Pathos put the word experimental in there and the tooltip talked about visual artifacts. BSM grid layout is really now ready for primetime IMO. Problem is there are ko and th translations. What to do there. Maybe remove the GMCM translations so those items fall back to default. Of course grid layout can still cause issues for other mods. e.g. Lookup Anything.

The grid layout still does not work in controller gamepad mode. I think I'll look at that. Something here may be how currentItem is handled in grid layout. currentItem 0, 1, 2, 3 is not shop item 0, 1, 2, 3. currentItem is actually a grid row so item1 is shop item 6.

Button remapping is not supported. Still hard coded to left/right click. Although things like keyboard equals do not operate in menus.

Considering expanding the width of the grid items. Not all menu space is being used and six figure price items have issues fitting their text. Not may six figure items. Maybe just do smaller text.