### PR TITLE
Fix for SeedShop in JA

### DIFF
--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -1385,7 +1385,7 @@ namespace JsonAssets
                 }
                 Log.Trace($"Adding objects for shop IDs '{string.Join("', '", shopIds)}'.");
 
-                bool isPierre = shopIds.Contains("Pierre");
+                bool isPierre = shopIds.Contains("Pierre") || shopIds.Contains("SeedShop");
                 bool isQiGemShop = shopIds.Contains("QiGemShop");
 
                 bool doAllSeeds = Game1.player.hasOrWillReceiveMail("PierreStocklist");


### PR DESCRIPTION
When Pierre goes to the Island the seed shop does not sell all seeds if the missing stock list has been acquired.

The code was looking at the name for the NPC portrait, but then Pierre is at the island the shop menu does not have his portrait.
I added code to look at the context id. Really only the context id needs to be checked, but this still works.