### PR TITLE
DGA more sensible 'missing items' message for big craftable machines

### DIFF
--- a/DynamicGameAssets/Game/CustomBigCraftable.cs
+++ b/DynamicGameAssets/Game/CustomBigCraftable.cs
@@ -215,13 +215,21 @@ namespace DynamicGameAssets.Game
                 else
                 {
                     if (!probe && StardewValley.Object.autoLoadChest == null)
-                        Game1.showRedMessage(Game1.content.LoadString("Strings\\StringsFromCSFiles:Object.cs.12772")); ;
+                    {
+                        // this means "Not Enough Resources"
+                        Game1.showRedMessage(Game1.content.LoadString("Strings\\StringsFromCSFiles:BlueprintsMenu.cs.10002"));
+                    }
+
                     return false;
                 }
             }
 
             if (!probe && StardewValley.Object.autoLoadChest == null)
-                Game1.showRedMessage(Game1.content.LoadString("Strings\\StringsFromCSFiles:Object.cs.12777"));
+            {
+                // this means "Not Enough Resources"
+                Game1.showRedMessage(Game1.content.LoadString("Strings\\StringsFromCSFiles:BlueprintsMenu.cs.10002"));
+            }
+
             return false;
         }
 


### PR DESCRIPTION
this replaces the messages
        "Object.cs.12772": "Requires 1 Coal"
        "Object.cs.12777": "Requires 5 ores."
with
        "BlueprintsMenu.cs.10002": "Not Enough Resources"