### PR TITLE
Dynamic height for GMCM Complex Options

### DIFF
--- a/GenericModConfigMenu/Framework/ComplexModOptionWidget.cs
+++ b/GenericModConfigMenu/Framework/ComplexModOptionWidget.cs
@@ -15,7 +15,7 @@ namespace GenericModConfigMenu.Framework
         public override int Width { get; } = 0;
 
         /// <inheritdoc />
-        public override int Height { get; }
+        public override int Height { get => ModOption.Height(); }
 
 
         /*********
@@ -24,7 +24,6 @@ namespace GenericModConfigMenu.Framework
         public ComplexModOptionWidget(ComplexModOption modOption)
         {
             this.ModOption = modOption;
-            this.Height = modOption.Height();
         }
 
         /// <inheritdoc />

--- a/GenericModConfigMenu/Framework/SpecificModConfigMenu.cs
+++ b/GenericModConfigMenu/Framework/SpecificModConfigMenu.cs
@@ -70,7 +70,7 @@ namespace GenericModConfigMenu.Framework
 
             this.ModConfig.ActiveDisplayPage = this.ModConfig.Pages[this.CurrPage];
 
-            this.Table = new Table
+            this.Table = new Table(fixedRowHeight: false)
             {
                 RowHeight = 50,
                 Size = new Vector2(Math.Min(1200, Game1.uiViewport.Width - 200), Game1.uiViewport.Height - 128 - 116)
@@ -323,17 +323,6 @@ namespace GenericModConfigMenu.Framework
 
                 this.Table.AddRow(new[] { label, optionElement, rightLabel }.Where(p => p != null).ToArray());
 
-                // add spacer rows for multi-row content
-                {
-                    int elementHeight = new[] { label?.Height, optionElement?.Height, rightLabel?.Height }.Max(p => p ?? 0);
-                    float overlapRows = ((elementHeight * 1.0f) / this.Table.RowHeight) - 1;
-
-                    if (overlapRows > 0.05f) // avoid adding an empty row if an element only overlaps slightly
-                    {
-                        for (int i = 0; i < overlapRows; i++)
-                            this.Table.AddRow(Array.Empty<Element>());
-                    }
-                }
             }
             this.Ui.AddChild(this.Table);
             this.AddDefaultLabels(this.Manifest);

--- a/GenericModConfigMenu/docs/release-notes.md
+++ b/GenericModConfigMenu/docs/release-notes.md
@@ -3,6 +3,7 @@
 # Release notes
 ## Upcoming release
 * The mod list now remembers your scroll position when returning from a config view (thanks to Pathoschild!).
+* Complex Options can now have Height that changes, rather than being fixed when the menu opens (thanks to jltaylor-us).
 
 ## 1.8.1
 Released 12 January 2022 for SMAPI 3.13.0 or later. Updated by Pathoschild.


### PR DESCRIPTION
This change updates the Table object in SpaceShared with an optional
parameter to the constructor to specify whether the table uses fixed row
hight (the existing behavior and new default) or lays out elements based
on their Height (which may change).  It also tweaks the computation of
whether elements are on screen so that the last element on the screen will
be partially drawn rather than leaving some amount of blank space that
gets drawn in once the page scrolls.

The GMCM SpecificModConfigMenu enables the new Table feature, and the
Complex option widget now passes though the call to Height each time it is
asked rather than setting a fixed height at construction.