### PR TITLE
Now with 100% more furniture catalogue

### DIFF
--- a/DynamicGameAssets/PackData/FurniturePackData.cs
+++ b/DynamicGameAssets/PackData/FurniturePackData.cs
@@ -67,6 +67,9 @@ namespace DynamicGameAssets.PackData
         [JsonConverter(typeof(StringEnumConverter))]
         public FurnitureType Type { get; set; }
 
+        [DefaultValue(true)]
+        public bool ShowInCatalogue { get; set; } = true;
+
         // Bed specific
         [JsonConverter(typeof(StringEnumConverter))]
         public BedFurniture.BedType BedType { get; set; } = BedFurniture.BedType.Single;

--- a/DynamicGameAssets/Patches/UtilityPatcher.cs
+++ b/DynamicGameAssets/Patches/UtilityPatcher.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using DynamicGameAssets.Game;
+using DynamicGameAssets.PackData;
 using HarmonyLib;
 using Microsoft.Xna.Framework;
 using Spacechase.Shared.Patching;
@@ -73,7 +74,7 @@ namespace DynamicGameAssets.Patches
                         continue;
 
                     var item = data.ToItem();
-                    if (item != null && item is Furniture)
+                    if (item != null && item is Furniture && data is FurniturePackData furnData && furnData.ShowInCatalogue)
                     {
                         __result.Add(item, new int[2] { 0, 2147483647 });
                     } 

--- a/DynamicGameAssets/Patches/UtilityPatcher.cs
+++ b/DynamicGameAssets/Patches/UtilityPatcher.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using DynamicGameAssets.Game;
 using HarmonyLib;
@@ -24,6 +25,11 @@ namespace DynamicGameAssets.Patches
             harmony.Patch(
                 original: this.RequireMethod<Utility>(nameof(Utility.isViableSeedSpot)),
                 prefix: this.GetHarmonyMethod(nameof(Before_IsViableSeedSpot))
+            );
+
+            harmony.Patch(
+                original: this.RequireMethod<Utility>(nameof(Utility.getAllFurnituresForFree)),
+                postfix: this.GetHarmonyMethod(nameof(After_GetAllFurnituresForFree))
             );
         }
 
@@ -54,6 +60,25 @@ namespace DynamicGameAssets.Patches
                 return false;
             }
             return true;
+        }
+
+        /// <summary>The method to call after <see cref="Utility.getAllFurnituresForFree"/>.</summary>
+        private static void After_GetAllFurnituresForFree(Dictionary<ISalable, int[]> __result)
+        {
+            foreach (var pack in Mod.contentPacks)
+            {
+                foreach (var data in pack.Value.items.Values)
+                {
+                    if (!data.Enabled)
+                        continue;
+
+                    var item = data.ToItem();
+                    if (item != null && item is Furniture)
+                    {
+                        __result.Add(item, new int[2] { 0, 2147483647 });
+                    } 
+                }
+            }
         }
     }
 }

--- a/DynamicGameAssets/docs/author-guide.md
+++ b/DynamicGameAssets/docs/author-guide.md
@@ -552,6 +552,7 @@ Furniture can be localized in the following keys: `"furniture.YourFurniture.name
 | `ID` | `string` | Required | The ID of this furniture. | `false` |
 | `Type` | `Enum[Bed, Decoration, Dresser, Fireplace, FishTank, Lamp, Painting, Rug, Table, Sconce, TV, Window]` | Required | The type of this furniture. | `false` |
 | `Configurations` | `FurnitureConfiguration[]` | Required | The configurations for this funriture. It uses the first configuration by default, and the others after being rotated. (NOTE: Fish tanks, beds, and TVs may only support one configuration!) | (unknown, untested) |
+| `ShowInCatalogue` | `bool` | Default: `true` | Whether the furniture shows up in the furniture catalogue. | (unknown, untested) |
 
 Certain furniture types have additional fields:
 


### PR DESCRIPTION
Adds all DGA furniture to the furniture catalogue. When the vanilla function pulls the furniture by type, it is also added to specific subtabs of the catalogue. Otherwise, it is just in the general tab. 

PS I think some of the changes GitHub shows are just newline things