### PR TITLE
[GMCM] Improved Text Rendering for Paragraphs

### DIFF
--- a/GenericModConfigMenu/Framework/SpecificModConfigMenu.cs
+++ b/GenericModConfigMenu/Framework/SpecificModConfigMenu.cs
@@ -273,7 +273,7 @@ namespace GenericModConfigMenu.Framework
 
                                     // else append if it fits
                                     string possibleLine = $"{nextLine} {word}".Trim();
-                                    if (Label.MeasureString(possibleLine).X <= this.Table.Size.X)
+                                    if (Label.MeasureString(possibleLine, font: Game1.smallFont).X <= this.Table.Size.X)
                                     {
                                         nextLine = possibleLine;
                                         continue;
@@ -292,8 +292,9 @@ namespace GenericModConfigMenu.Framework
                             optionElement = new Label
                             {
                                 UserData = tooltip,
-                                NonBoldScale = 0.75f,
+                                NonBoldScale = 1f,
                                 NonBoldShadow = false,
+                                Font = Game1.smallFont,
                                 String = text.ToString()
                             };
                             break;

--- a/SpaceShared/UI/Label.cs
+++ b/SpaceShared/UI/Label.cs
@@ -24,6 +24,8 @@ namespace SpaceShared.UI
         public Color IdleTextColor { get; set; } = Game1.textColor;
         public Color HoverTextColor { get; set; } = Game1.unselectedOptionColor;
 
+        public SpriteFont Font { get; set; } = Game1.dialogueFont;
+
         public float Scale => this.Bold ? 1f : this.NonBoldScale;
 
         public string String { get; set; }
@@ -55,7 +57,7 @@ namespace SpaceShared.UI
         /// <summary>Measure the label's rendered dialogue text size.</summary>
         public Vector2 Measure()
         {
-            return Label.MeasureString(this.String, this.Bold, scale: this.Bold ? 1f : this.NonBoldScale);
+            return Label.MeasureString(this.String, this.Bold, scale: this.Bold ? 1f : this.NonBoldScale, font: this.Font);
         }
 
         /// <inheritdoc />
@@ -74,9 +76,9 @@ namespace SpaceShared.UI
                     return;
 
                 if (this.NonBoldShadow)
-                    Utility.drawTextWithShadow(b, this.String, Game1.dialogueFont, this.Position, col, this.NonBoldScale);
+                    Utility.drawTextWithShadow(b, this.String, this.Font, this.Position, col, this.NonBoldScale);
                 else
-                    b.DrawString(Game1.dialogueFont, this.String, this.Position, col, 0f, Vector2.Zero, this.NonBoldScale, SpriteEffects.None, 1);
+                    b.DrawString(this.Font, this.String, this.Position, col, 0f, Vector2.Zero, this.NonBoldScale, SpriteEffects.None, 1);
             }
         }
 
@@ -84,12 +86,12 @@ namespace SpaceShared.UI
         /// <param name="text">The text to measure.</param>
         /// <param name="bold">Whether the font is bold.</param>
         /// <param name="scale">The scale to apply to the size.</param>
-        public static Vector2 MeasureString(string text, bool bold = false, float scale = 1f)
+        public static Vector2 MeasureString(string text, bool bold = false, float scale = 1f, SpriteFont font = null)
         {
             if (bold)
                 return new Vector2(SpriteText.getWidthOfString(text) * scale, SpriteText.getHeightOfString(text) * scale);
             else
-                return Game1.dialogueFont.MeasureString(text) * scale;
+                return (font ?? Game1.dialogueFont).MeasureString(text) * scale;
         }
     }
 }

--- a/SpaceShared/UI/Label.cs
+++ b/SpaceShared/UI/Label.cs
@@ -24,7 +24,7 @@ namespace SpaceShared.UI
         public Color IdleTextColor { get; set; } = Game1.textColor;
         public Color HoverTextColor { get; set; } = Game1.unselectedOptionColor;
 
-        public SpriteFont Font { get; set; } = Game1.dialogueFont;
+        public SpriteFont Font { get; set; } = Game1.dialogueFont; // Only applies when Bold = false
 
         public float Scale => this.Bold ? 1f : this.NonBoldScale;
 
@@ -86,6 +86,7 @@ namespace SpaceShared.UI
         /// <param name="text">The text to measure.</param>
         /// <param name="bold">Whether the font is bold.</param>
         /// <param name="scale">The scale to apply to the size.</param>
+        /// <param name="font">The font to measure. Defaults to <see cref="Game1.dialogueFont"/> if <c>null</c>.</param>
         public static Vector2 MeasureString(string text, bool bold = false, float scale = 1f, SpriteFont font = null)
         {
             if (bold)


### PR DESCRIPTION
This pull request:

1. Adds a `Font` property to `SpaceShared.UI.Label` which defaults to `Game1.dialogueFont` to preserve existing behavior.
2. Changes `SpecificModConfigMenu` to use the new font property to use `Game1.smallFont` for rendering paragraphs, rather than using a scaled dialogue font.

This improves text rendering, as demonstrated in this image. The old method with scaled dialogue font is on top, and the new method with small font is on the bottom:

![image](https://user-images.githubusercontent.com/41554123/162279677-2f26b6c5-9cf7-4b86-a1c3-9459cc7eafd0.png)
