### PR TITLE
Remove division by 0 error in content pack textures, handle underwidth textures better

### DIFF
--- a/DynamicGameAssets/PackData/ContentPack.cs
+++ b/DynamicGameAssets/PackData/ContentPack.cs
@@ -314,7 +314,7 @@ namespace DynamicGameAssets.PackData
                 }
                 else
                 {
-                    Log.Warn($"No such \"{frame.FilePath}\" in {this.smapiPack.Manifest.Name} ({this.smapiPack.Manifest.UniqueID})!");
+                    Log.Error($"No such \"{frame.FilePath}\" in {this.smapiPack.Manifest.Name} ({this.smapiPack.Manifest.UniqueID})!");
                     texture = null;
                 }
 

--- a/DynamicGameAssets/PackData/ContentPack.cs
+++ b/DynamicGameAssets/PackData/ContentPack.cs
@@ -301,6 +301,10 @@ namespace DynamicGameAssets.PackData
                     try
                     {
                         texture = this.smapiPack.LoadAsset<Texture2D>(frame.FilePath);
+                        if (texture.Width < xSize)
+                        {
+                            Log.Warn($"Underwidth texture in \"{frame.FilePath}\" in {this.smapiPack.Manifest.Name} ({this.smapiPack.Manifest.UniqueID})!");
+                        }
                         texture.Name = PathUtilities.NormalizeAssetName($"DGA/{this.smapiPack.Manifest.UniqueID}/{frame.FilePath}");
                     }
                     catch
@@ -315,16 +319,19 @@ namespace DynamicGameAssets.PackData
                 }
 
                 texture ??= Game1.staminaRect;
+                
                 this.TextureCache[frame.FilePath] = texture;
             }
 
             // build texture + source rectangle
-            int spriteColumns = texture.Width / xSize;
+            int spriteColumns = texture.Width > xSize ? texture.Width / xSize : 1;
             int index = frame.SpriteIndex;
+            int rectWidth = texture.Width > xSize ? xSize : texture.Width;
+            int rectHeight = texture.Height > ySize ? ySize : texture.Height;
             return new TexturedRect
             {
                 Texture = texture,
-                Rect = new Rectangle(index % spriteColumns * xSize, index / spriteColumns * ySize, xSize, ySize)
+                Rect = new Rectangle(index % spriteColumns * xSize, index / spriteColumns * ySize, rectWidth, rectHeight)
             };
         }
     }


### PR DESCRIPTION
What this does:
- Adds a warning when the texture loaded has a width less than the requested width
- Throws an error when a texture is expected but not found at the file path (you may want to leave this as a warning it's a separate commit so you can ask me to re-PR if you want or just remove that commit if you can do that)
- Handles the cases when the texture width is less than the requested width, which due to integer math was making the sprite columns be 0—now they are at minimum 1
- Changes the rectangle widths/heights so that undersized textures draw in a mostly okay way