### PR TITLE
Boots crash fix

### DIFF
--- a/DynamicGameAssets/Mod.cs
+++ b/DynamicGameAssets/Mod.cs
@@ -195,7 +195,7 @@ namespace DynamicGameAssets
                 if (farmer.boots.Value is CustomBoots boots)
                 {
                     TextureAnimationFrame frame = boots.Data.pack.GetTextureFrame(boots.Data.FarmerColors);
-                    if (this.prevBootsFrame.GetOrCreateValue(farmer).Value != frame.Descriptor)
+                    if (frame is not null && this.prevBootsFrame.GetOrCreateValue(farmer).Value != frame.Descriptor)
                     {
                         if (this.prevBootsFrame.TryGetValue(farmer, out var holder))
                             holder.Value = frame.Descriptor;

--- a/DynamicGameAssets/Patches/FarmerRendererPatcher.cs
+++ b/DynamicGameAssets/Patches/FarmerRendererPatcher.cs
@@ -52,11 +52,8 @@ namespace DynamicGameAssets.Patches
         {
             var this_shoes = Mod.instance.Helper.Reflection.GetField<NetInt>(__instance, "shoes").GetValue();
 
-            Log.Debug($"Shoe value is {this_shoes.ToString()}");
-
             if (Mod.itemLookup.ContainsKey(this_shoes.Value))
             {
-                Log.Debug($"Doing the thing to the shoes");
                 BootsPackData data = Mod.Find(Mod.itemLookup[this_shoes.Value]) as BootsPackData;
                 var this__SwapColor = Mod.instance.Helper.Reflection.GetMethod(__instance, "_SwapColor");
 

--- a/DynamicGameAssets/Patches/FarmerRendererPatcher.cs
+++ b/DynamicGameAssets/Patches/FarmerRendererPatcher.cs
@@ -82,14 +82,16 @@ namespace DynamicGameAssets.Patches
         }
 
         /// <summary>The method to call as a finalized on <see cref="FarmerRenderer.ApplyShoeColor"/>.</summary>
-        private static void Finalizer_ApplyShoeColor(Exception __exception, FarmerRenderer __instance)
+        private static Exception Finalizer_ApplyShoeColor(Exception __exception, FarmerRenderer __instance)
         {
             if (__exception is not null)
             {
                 var this_shoes = Mod.instance.Helper.Reflection.GetField<NetInt>(__instance, "shoes").GetValue();
                 Log.Warn($"Detected invalid boots with value {this_shoes.ToString()} and error {__exception}");
                 __instance.recolorShoes(0);
+                return null;
             }
+            return null;
         }
 
         /// <summary>The method to call before <see cref="FarmerRenderer.ApplySleeveColor"/>.</summary>

--- a/DynamicGameAssets/Patches/FarmerRendererPatcher.cs
+++ b/DynamicGameAssets/Patches/FarmerRendererPatcher.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 using DynamicGameAssets.Game;
 using DynamicGameAssets.PackData;
@@ -24,7 +25,8 @@ namespace DynamicGameAssets.Patches
         {
             harmony.Patch(
                 original: this.RequireMethod<FarmerRenderer>("ApplyShoeColor"),
-                prefix: this.GetHarmonyMethod(nameof(Before_ApplyShoeColor))
+                prefix: this.GetHarmonyMethod(nameof(Before_ApplyShoeColor)),
+                finalizer: this.GetHarmonyMethod(nameof(Finalizer_ApplyShoeColor))
             );
             harmony.Patch(
                 original: this.RequireMethod<FarmerRenderer>(nameof(FarmerRenderer.ApplySleeveColor)),
@@ -50,8 +52,11 @@ namespace DynamicGameAssets.Patches
         {
             var this_shoes = Mod.instance.Helper.Reflection.GetField<NetInt>(__instance, "shoes").GetValue();
 
+            Log.Debug($"Shoe value is {this_shoes.ToString()}");
+
             if (Mod.itemLookup.ContainsKey(this_shoes.Value))
             {
+                Log.Debug($"Doing the thing to the shoes");
                 BootsPackData data = Mod.Find(Mod.itemLookup[this_shoes.Value]) as BootsPackData;
                 var this__SwapColor = Mod.instance.Helper.Reflection.GetMethod(__instance, "_SwapColor");
 
@@ -74,6 +79,17 @@ namespace DynamicGameAssets.Patches
             }
 
             return true;
+        }
+
+        /// <summary>The method to call as a finalized on <see cref="FarmerRenderer.ApplyShoeColor"/>.</summary>
+        private static void Finalizer_ApplyShoeColor(Exception __exception, FarmerRenderer __instance)
+        {
+            if (__exception is not null)
+            {
+                var this_shoes = Mod.instance.Helper.Reflection.GetField<NetInt>(__instance, "shoes").GetValue();
+                Log.Warn($"Detected invalid boots with value {this_shoes.ToString()} and error {__exception}");
+                __instance.recolorShoes(0);
+            }
         }
 
         /// <summary>The method to call before <see cref="FarmerRenderer.ApplySleeveColor"/>.</summary>


### PR DESCRIPTION
Fixes the crash that happens when you wear shoes to sleep and then remove the content pack adding them (or switch to a different mod group)
- Adds a null check
- Adds a finalizer that resets the boots color and logs the error
With this installed, you can load up a save without the content pack, and everything is fine. You can also remove and trash the boots if you want (they show up as a null item). 

Note that this will not fix any issues unless DGA is installed—I don't know of a way to do that, personally.