### PR TITLE
Festival shop fix

### DIFF
--- a/DynamicGameAssets/ShopEntry.cs
+++ b/DynamicGameAssets/ShopEntry.cs
@@ -13,12 +13,18 @@ namespace DynamicGameAssets
 
         public void AddToShop(ShopMenu shop)
         {
+            // Check to see if this shopEntry has already been added to this shop--if so, don't add
+            if (shop.itemPriceAndStock.ContainsKey(this.Item))
+                return;
+
             int qty = this.Quantity;
             if (this.Item is StardewValley.Object { IsRecipe: true })
                 qty = 1;
 
             this.Item.Stack = qty;
-            shop.forSale.Add(this.Item);
+            if (!shop.forSale.Contains(this.Item)) {
+                shop.forSale.Add(this.Item);
+            }
             if (this.CurrencyId == null)
             {
                 shop.itemPriceAndStock.Add(this.Item, new[]

--- a/DynamicGameAssets/ShopEntry.cs
+++ b/DynamicGameAssets/ShopEntry.cs
@@ -22,9 +22,7 @@ namespace DynamicGameAssets
                 qty = 1;
 
             this.Item.Stack = qty;
-            if (!shop.forSale.Contains(this.Item)) {
-                shop.forSale.Add(this.Item);
-            }
+            shop.forSale.Add(this.Item);
             if (this.CurrencyId == null)
             {
                 shop.itemPriceAndStock.Add(this.Item, new[]


### PR DESCRIPTION
The festival shop error was resulting from checkAction being called multiple times, instead of just once, meaning the same festival shop stock was being added 2-3 times. This just adds a check for the item already being in the list of keys, circumventing the error seen in the log and making sure the items show in the shop the right number of times (i.e. once per shop entry). 