### PR TITLE
Furniture draw fix

### DIFF
--- a/DynamicGameAssets/Game/CustomBasicFurniture.cs
+++ b/DynamicGameAssets/Game/CustomBasicFurniture.cs
@@ -106,8 +106,17 @@ namespace DynamicGameAssets.Game
                 }
                 else
                 {
-                    spriteBatch.Draw(Game1.shadowTexture, Game1.GlobalToLocal(Game1.viewport, new Vector2(this.boundingBox.Center.X - 32, this.boundingBox.Center.Y - (this.drawHeldObjectLow ? 32 : 85))) + new Vector2(32f, 53f), Game1.shadowTexture.Bounds, Color.White * alpha, 0f, new Vector2(Game1.shadowTexture.Bounds.Center.X, Game1.shadowTexture.Bounds.Center.Y), 4f, SpriteEffects.None, (float)this.boundingBox.Bottom / 10000f);
-                    spriteBatch.Draw(Game1.objectSpriteSheet, Game1.GlobalToLocal(Game1.viewport, new Vector2(this.boundingBox.Center.X - 32, this.boundingBox.Center.Y - (this.drawHeldObjectLow ? 32 : 85))), GameLocation.getSourceRectForObject(this.heldObject.Value.ParentSheetIndex), Color.White * alpha, 0f, Vector2.Zero, 4f, SpriteEffects.None, (float)(this.boundingBox.Bottom + 1) / 10000f);
+                    spriteBatch.Draw(Game1.shadowTexture, Game1.GlobalToLocal(Game1.viewport, new Vector2(this.boundingBox.Center.X - 32, this.boundingBox.Center.Y - (this.drawHeldObjectLow.Value ? 32 : 85))) + new Vector2(32f, 53f), Game1.shadowTexture.Bounds, Color.White * alpha, 0f, new Vector2(Game1.shadowTexture.Bounds.Center.X, Game1.shadowTexture.Bounds.Center.Y), 4f, SpriteEffects.None, (float)this.boundingBox.Bottom / 10000f);
+                    if (this.heldObject.Value is CustomObject customObject)
+                    {
+                        Vector2 position = new Vector2(this.boundingBox.Center.X - 32, this.boundingBox.Center.Y - (this.drawHeldObjectLow.Value ? 32 : 85));
+                        customObject.draw(spriteBatch, (int)position.X, (int)position.Y, (float)(this.boundingBox.Bottom + 1) / 10000f + 0.5f, alpha);
+                    }
+                    else
+                    {
+                        spriteBatch.Draw(Game1.objectSpriteSheet, Game1.GlobalToLocal(Game1.viewport, new Vector2(this.boundingBox.Center.X - 32, this.boundingBox.Center.Y - (this.drawHeldObjectLow.Value ? 32 : 85))), GameLocation.getSourceRectForObject(this.heldObject.Value.ParentSheetIndex), Color.White * alpha, 0f, Vector2.Zero, 4f, SpriteEffects.None, (float)(this.boundingBox.Bottom + 1) / 10000f);
+
+                    }
                 }
             }
             if ((bool)this.isOn && (int)this.furniture_type == 14)

--- a/DynamicGameAssets/Game/CustomObject.cs
+++ b/DynamicGameAssets/Game/CustomObject.cs
@@ -277,6 +277,29 @@ namespace DynamicGameAssets.Game
             }
         }
 
+        public void drawWithoutShadow(SpriteBatch spriteBatch, int xNonTile, int yNonTile, float layerDepth, float alpha = 1)
+        {
+            if (this.isTemporarilyInvisible)
+                return;
+
+            if (!Game1.eventUp || !Game1.CurrentEvent.isTileWalkedOn(xNonTile / 64, yNonTile / 64))
+            {
+                var tex = this.Data.pack.GetTexture(this.Data.Texture, 16, 16);
+                Texture2D objectSpriteSheet = tex.Texture;
+                Vector2 position2 = Game1.GlobalToLocal(Game1.viewport, new Vector2(xNonTile + 32 + ((this.shakeTimer > 0) ? Game1.random.Next(-1, 2) : 0), yNonTile + 32 + ((this.shakeTimer > 0) ? Game1.random.Next(-1, 2) : 0)));
+                Rectangle? sourceRectangle = tex.Rect; // GameLocation.getSourceRectForObject(base.ParentSheetIndex);
+                Color color = Color.White * alpha;
+                Vector2 origin = new Vector2(8f, 8f);
+                _ = this.scale;
+                spriteBatch.Draw(objectSpriteSheet, position2, sourceRectangle, color, 0f, origin, (this.scale.Y > 1f) ? this.getScale().Y : 4f, this.flipped ? SpriteEffects.FlipHorizontally : SpriteEffects.None, layerDepth);
+                if (this.NetHasColor.Value)
+                {
+                    var colorTex = this.Data.pack.GetTexture(this.Data.TextureColor, 16, 16);
+                    spriteBatch.Draw(colorTex.Texture, position2, colorTex.Rect, this.ObjectColor.Value, 0f, origin, (this.scale.Y > 1f) ? this.getScale().Y : 4f, this.flipped ? SpriteEffects.FlipHorizontally : SpriteEffects.None, layerDepth + 2e-05f);
+                }
+            }
+        }
+
         public override Item getOne()
         {
             var ret = new CustomObject(this.Data);

--- a/DynamicGameAssets/Game/CustomObject.cs
+++ b/DynamicGameAssets/Game/CustomObject.cs
@@ -299,6 +299,20 @@ namespace DynamicGameAssets.Game
 
         public override bool canBePlacedHere(GameLocation l, Vector2 tile)
         {
+            Vector2 nonTile = tile * 64f * 64f;
+            nonTile.X += 32f;
+            nonTile.Y += 32f;
+            foreach (Furniture f in l.furniture)
+            {
+                if ((int)f.furniture_type.Value == 11 && f.getBoundingBox(f.TileLocation).Contains((int)nonTile.X, (int)nonTile.Y) && f.heldObject.Value == null)
+                {
+                    return true;
+                }
+                if (f.getBoundingBox(f.TileLocation).Intersects(new Rectangle((int)tile.X * 64, (int)tile.Y * 64, 64, 64)) && !f.isPassable() && !f.AllowPlacementOnThisTile((int)tile.X, (int)tile.Y))
+                {
+                    return false;
+                }
+            }
             return this.isPlaceable() && !l.isTileOccupiedForPlacement(tile, this);
         }
 

--- a/DynamicGameAssets/Patches/FurniturePatcher.cs
+++ b/DynamicGameAssets/Patches/FurniturePatcher.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using DynamicGameAssets.Game;
 using HarmonyLib;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Spacechase.Shared.Patching;
 using SpaceShared;
 using StardewModdingAPI;
@@ -31,6 +33,10 @@ namespace DynamicGameAssets.Patches
                 original: this.RequireMethod<Furniture>(nameof(Furniture.placementAction)),
                 postfix: this.GetHarmonyMethod(nameof(After_PlacementAction))
             );
+            harmony.Patch(
+                 original: this.RequireMethod<Furniture>(nameof(Furniture.drawAtNonTileSpot)),
+                 prefix: this.GetHarmonyMethod(nameof(Before_drawAtNonTileSpot))
+             );
         }
 
 
@@ -76,6 +82,19 @@ namespace DynamicGameAssets.Patches
                 if (furniture.furniture_type.Value is Furniture.lamp or Furniture.sconce)
                     furniture.resetOnPlayerEntry(location);
             }
+        }
+
+        /// <summary>The method to call before <see cref="Furniture.drawAtNonTileSpot"/>.</summary>
+        /// <returns>Returns whether to run the original method.</returns>
+        private static bool Before_drawAtNonTileSpot(Furniture __instance, SpriteBatch spriteBatch, Vector2 location, float layerDepth, float alpha)
+        {
+            if (__instance is CustomBasicFurniture furniture)
+            {
+                furniture.drawAtNonTileSpot(spriteBatch, location, layerDepth, alpha);
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/DynamicGameAssets/Patches/FurniturePatcher.cs
+++ b/DynamicGameAssets/Patches/FurniturePatcher.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 using DynamicGameAssets.Game;
 using HarmonyLib;
@@ -36,7 +37,11 @@ namespace DynamicGameAssets.Patches
             harmony.Patch(
                  original: this.RequireMethod<Furniture>(nameof(Furniture.drawAtNonTileSpot)),
                  prefix: this.GetHarmonyMethod(nameof(Before_drawAtNonTileSpot))
-             );
+            );
+            harmony.Patch(
+                original: this.RequireMethod<Furniture>(nameof(Furniture.draw), new Type[] { typeof(SpriteBatch), typeof(int), typeof(int), typeof(float) }),
+                postfix: this.GetHarmonyMethod(nameof(After_draw))
+            );
         }
 
 
@@ -95,6 +100,20 @@ namespace DynamicGameAssets.Patches
             }
 
             return true;
+        }
+
+        /// <summary>The method to call before <see cref="Furniture.draw"/>.</summary>
+        private static void After_draw(Furniture __instance, SpriteBatch spriteBatch, int x, int y, float alpha)
+        {
+            // If this is a table, and not a DGA table, and there is a DGA object on the table
+            if ((__instance.furniture_type == Furniture.table || __instance.furniture_type == Furniture.longTable) &&
+                __instance is not CustomBasicFurniture && __instance.heldObject.Value is CustomObject heldObject)
+            {
+                int xLocation = __instance.boundingBox.Center.X - 32;
+                int yLocation = __instance.boundingBox.Center.Y - (__instance.drawHeldObjectLow ? 32 : 85);
+                float heldLayerDepth = (float)(__instance.boundingBox.Bottom + 1) / 10000f;
+                heldObject.drawWithoutShadow(spriteBatch, xLocation, yLocation, heldLayerDepth, alpha);
+            }
         }
     }
 }


### PR DESCRIPTION
From shekurika's PR:
- Fixes DGA furniture drawing on top of DGA furniture
- Fixes DGA furniture drawing on top of vanilla furniture
- Fixes DGA objects drawing on top of DGA furniture
New fix:
- Fixes DGA objects drawing on top of vanilla furniture by adding a new drawWithoutShadow function to CustomObject, and then postfixing the Furniture.cs draw function to re-draw the DGA object correctly (since it draws some kind of nonexistent invisible object from springobjects.png right now)