### PR TITLE
Add night texture option to furniture

### DIFF
--- a/DynamicGameAssets/Game/CustomBasicFurniture.cs
+++ b/DynamicGameAssets/Game/CustomBasicFurniture.cs
@@ -79,7 +79,15 @@ namespace DynamicGameAssets.Game
             }
 
             var currConfig = this.GetCurrentConfiguration();
-            var currTex = this.Data.pack.GetTexture(currConfig.Texture, (int)currConfig.DisplaySize.X * Game1.tileSize / Game1.pixelZoom, (int)currConfig.DisplaySize.Y * Game1.tileSize / Game1.pixelZoom);
+            TexturedRect currTex = null;
+            if (Game1.isDarkOut() && currConfig.NightTexture != null)
+            {
+                currTex = this.Data.pack.GetTexture(currConfig.NightTexture, (int)currConfig.DisplaySize.X * Game1.tileSize / Game1.pixelZoom, (int)currConfig.DisplaySize.Y * Game1.tileSize / Game1.pixelZoom);
+            }
+            else
+            {
+                currTex = this.Data.pack.GetTexture(currConfig.Texture, (int)currConfig.DisplaySize.X * Game1.tileSize / Game1.pixelZoom, (int)currConfig.DisplaySize.Y * Game1.tileSize / Game1.pixelZoom);
+            }
             var frontTex = currConfig.FrontTexture != null ? this.Data.pack.GetTexture(currConfig.FrontTexture, (int)currConfig.DisplaySize.X * Game1.tileSize / Game1.pixelZoom, (int)currConfig.DisplaySize.Y * Game1.tileSize / Game1.pixelZoom) : null;
 
             if (Furniture.isDrawingLocationFurniture)

--- a/DynamicGameAssets/Game/CustomBasicFurniture.cs
+++ b/DynamicGameAssets/Game/CustomBasicFurniture.cs
@@ -136,7 +136,15 @@ namespace DynamicGameAssets.Game
         public void drawAtNonTileSpot(SpriteBatch spriteBatch, Vector2 location, float layerDepth, float alpha = 1f)
         {
             var currConfig = this.GetCurrentConfiguration();
-            var currTex = this.Data.pack.GetTexture(currConfig.Texture, (int)currConfig.DisplaySize.X * Game1.tileSize / Game1.pixelZoom, (int)currConfig.DisplaySize.Y * Game1.tileSize / Game1.pixelZoom);
+            TexturedRect currTex = null;
+            if (Game1.isDarkOut() && currConfig.NightTexture != null)
+            {
+                currTex = this.Data.pack.GetTexture(currConfig.NightTexture, (int)currConfig.DisplaySize.X * Game1.tileSize / Game1.pixelZoom, (int)currConfig.DisplaySize.Y * Game1.tileSize / Game1.pixelZoom);
+            }
+            else
+            {
+                currTex = this.Data.pack.GetTexture(currConfig.Texture, (int)currConfig.DisplaySize.X * Game1.tileSize / Game1.pixelZoom, (int)currConfig.DisplaySize.Y * Game1.tileSize / Game1.pixelZoom);
+            }
 
             spriteBatch.Draw(currTex.Texture, location, currTex.Rect, Color.White * alpha, 0f, Vector2.Zero, 4f, this.flipped ? SpriteEffects.FlipHorizontally : SpriteEffects.None, layerDepth);
         }

--- a/DynamicGameAssets/PackData/FurniturePackData.cs
+++ b/DynamicGameAssets/PackData/FurniturePackData.cs
@@ -28,6 +28,9 @@ namespace DynamicGameAssets.PackData
             [DefaultValue(null)]
             public string FrontTexture { get; set; } // for seats, beds, fish tanks
 
+            [DefaultValue(null)]
+            public string NightTexture { get; set; } // for lamps, windows, sconces
+
             public Vector2 DisplaySize { get; set; }
             public int CollisionHeight { get; set; }
 

--- a/DynamicGameAssets/docs/author-guide.md
+++ b/DynamicGameAssets/docs/author-guide.md
@@ -573,7 +573,8 @@ This should be an array of an an object called `FurnitureConfiguration`. A `Furn
 | Field | Type | Required or Default value | Description |
 | --- | --- | --- | --- |
 | `Texture` | `Texture` | Required | The texture for this configuration. |
-| `FrontTexture` | `Texture` | Required* | (* Only required for beds/fish tanks, and if this has seats.) The texture for this configuration to render on top. |
+| `FrontTexture` | `Texture` | Optional* (Default: `null`) | (* Required for beds/fish tanks/furniture with seats to look right.) The texture for this configuration to render on top. |
+| `FrontTexture` | `Texture` | Optional* (Default: `null`) | (* Required for windows, sconces, and lamps to look right.) The texture for this configuration to render when it's nighttime. |
 | `DisplaySize` | `Vector2` | Required | The display size of this furniture, in tiles. |
 | `CollisionHeight` | `int` | Required | How high from the bottom this furniture is solid. |
 | `Flipped` | `bool` | Default: `false` | If the texture is flipped or not. |

--- a/DynamicGameAssets/docs/author-guide.md
+++ b/DynamicGameAssets/docs/author-guide.md
@@ -574,7 +574,7 @@ This should be an array of an an object called `FurnitureConfiguration`. A `Furn
 | --- | --- | --- | --- |
 | `Texture` | `Texture` | Required | The texture for this configuration. |
 | `FrontTexture` | `Texture` | Optional* (Default: `null`) | (* Required for beds/fish tanks/furniture with seats to look right.) The texture for this configuration to render on top. |
-| `FrontTexture` | `Texture` | Optional* (Default: `null`) | (* Required for windows, sconces, and lamps to look right.) The texture for this configuration to render when it's nighttime. |
+| `NightTexture` | `Texture` | Optional* (Default: `null`) | (* Required for windows, sconces, and lamps to look right.) The texture for this configuration to render when it's nighttime. |
 | `DisplaySize` | `Vector2` | Required | The display size of this furniture, in tiles. |
 | `CollisionHeight` | `int` | Required | How high from the bottom this furniture is solid. |
 | `Flipped` | `bool` | Default: `false` | If the texture is flipped or not. |


### PR DESCRIPTION
This adds night textures to furniture in order to be able to make lamps, windows, and sconces appear correctly. 