### PR TITLE
Changing debug to trace in some logging statements

### DIFF
--- a/DynamicGameAssets/Mod.cs
+++ b/DynamicGameAssets/Mod.cs
@@ -640,7 +640,7 @@ namespace DynamicGameAssets
 
         internal static void AddEmbeddedContentPack(IManifest manifest, string dir)
         {
-            Log.Debug($"Loading embedded content pack for \"{manifest.Name}\"...");
+            Log.Trace($"Loading embedded content pack for \"{manifest.Name}\"...");
             if (manifest.ExtraFields == null ||
                  !manifest.ExtraFields.ContainsKey("DGA.FormatVersion") ||
                  !int.TryParse(manifest.ExtraFields["DGA.FormatVersion"].ToString(), out int formatVer))
@@ -669,7 +669,7 @@ namespace DynamicGameAssets
         {
             foreach (var cp in this.Helper.ContentPacks.GetOwned())
             {
-                Log.Debug($"Loading content pack \"{cp.Manifest.Name}\"...");
+                Log.Trace($"Loading content pack \"{cp.Manifest.Name}\"...");
                 if (cp.Manifest.ExtraFields == null ||
                      !cp.Manifest.ExtraFields.ContainsKey("DGA.FormatVersion") ||
                      !int.TryParse(cp.Manifest.ExtraFields["DGA.FormatVersion"].ToString(), out int formatVer))

--- a/DynamicGameAssets/PackData/DynamicFieldData.cs
+++ b/DynamicGameAssets/PackData/DynamicFieldData.cs
@@ -62,7 +62,7 @@ namespace DynamicGameAssets.PackData
             {
                 string Field = singleField.Key;
                 JToken Data = singleField.Value;
-                Log.Debug( "parsing:"+Field+" and "+Data );
+                Log.Trace( "parsing:"+Field+" and "+Data );
                 if (Data.ToString().Contains("{{"))
                 {
                     string strData = Data.ToString();


### PR DESCRIPTION
A few different places had debug statements that logged a lot of information at Debug level. Changing them to Trace so that users can still read their logs, but the information is there in case it's needed for debugging (the last one is especially important for debugging dynamic fields when making mods).