### PR TITLE
Fix for the display names of Wine, Juice, Pickles, and Jelly made from DGA items

### DIFF
--- a/DynamicGameAssets/Patches/ObjectPatcher.cs
+++ b/DynamicGameAssets/Patches/ObjectPatcher.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq.Expressions;
-using System.Reflection;
 using DynamicGameAssets.Game;
 using DynamicGameAssets.PackData;
 using HarmonyLib;

--- a/DynamicGameAssets/Patches/ObjectPatcher.cs
+++ b/DynamicGameAssets/Patches/ObjectPatcher.cs
@@ -40,10 +40,10 @@ namespace DynamicGameAssets.Patches
                 original: this.RequireMethod<SObject>(nameof(SObject.performObjectDropInAction)),
                 postfix: this.GetHarmonyMethod(nameof(After_PerformObjectDropInAction))
             );
-            //harmony.Patch(
-            //    original: this.RequireMethod<SObject>("loadDisplayName"),
-            //    postfix: this.GetHarmonyMethod(nameof(After_LoadDisplayName))
-            //);
+            harmony.Patch(
+                original: this.RequireMethod<SObject>("loadDisplayName"),
+                postfix: this.GetHarmonyMethod(nameof(After_LoadDisplayName))
+            );
         }
 
 
@@ -166,7 +166,6 @@ namespace DynamicGameAssets.Patches
             string dga_parent_ID = __instance.modData["spacechase0.DynamicGameAssets/preserved-parent-ID"];
             if (dga_parent_ID != null && __instance.preserve.Value != null && Mod.Find(dga_parent_ID).ToItem() is CustomObject parentItem)
             {
-                Log.Debug("Changing Display Name for DGA parent object");
                 switch (__instance.preserve.Value)
                 {
                     case SObject.PreserveType.Wine:

--- a/DynamicGameAssets/Patches/ObjectPatcher.cs
+++ b/DynamicGameAssets/Patches/ObjectPatcher.cs
@@ -160,25 +160,37 @@ namespace DynamicGameAssets.Patches
         /// <summary>The method to call after <see cref="SObject.loadDisplayName"/>.</summary>
         private static void After_LoadDisplayName(SObject __instance, ref string __result)
         {
-            string dga_parent_ID = __instance.modData["spacechase0.DynamicGameAssets/preserved-parent-ID"];
-            if (dga_parent_ID != null && __instance.preserve.Value != null && Mod.Find(dga_parent_ID).ToItem() is CustomObject parentItem)
+            if (!__instance.preserve.Value.HasValue)
             {
-                switch (__instance.preserve.Value)
+                return;
+            }
+            
+            if (__instance.modData.ContainsKey("spacechase0.DynamicGameAssets/preserved-parent-ID"))
+            {
+                string dga_parent_ID = __instance.modData["spacechase0.DynamicGameAssets/preserved-parent-ID"];
+                if (Mod.Find(dga_parent_ID).ToItem() is CustomObject parentItem)
                 {
-                    case SObject.PreserveType.Wine:
-                        __result = Game1.content.LoadString("Strings\\StringsFromCSFiles:Object.cs.12730", parentItem.DisplayName);
-                        return;
-                    case SObject.PreserveType.Jelly:
-                        __result = Game1.content.LoadString("Strings\\StringsFromCSFiles:Object.cs.12739", parentItem.DisplayName);
-                        return;
-                    case SObject.PreserveType.Pickle:
-                        __result = Game1.content.LoadString("Strings\\StringsFromCSFiles:Object.cs.12735", parentItem.DisplayName);
-                        return;
-                    case SObject.PreserveType.Juice:
-                        __result = Game1.content.LoadString("Strings\\StringsFromCSFiles:Object.cs.12726", parentItem.DisplayName);
-                        return;
+                    //Log.Debug($"Changing display name for preserved item with parent named {parentItem.DisplayName}");
+                    switch (__instance.preserve.Value)
+                    {
+                        case SObject.PreserveType.Wine:
+                            __result = Game1.content.LoadString("Strings\\StringsFromCSFiles:Object.cs.12730", parentItem.DisplayName);
+                            return;
+                        case SObject.PreserveType.Jelly:
+                            __result = Game1.content.LoadString("Strings\\StringsFromCSFiles:Object.cs.12739", parentItem.DisplayName);
+                            return;
+                        case SObject.PreserveType.Pickle:
+                            __result = Game1.content.LoadString("Strings\\StringsFromCSFiles:Object.cs.12735", parentItem.DisplayName);
+                            return;
+                        case SObject.PreserveType.Juice:
+                            __result = Game1.content.LoadString("Strings\\StringsFromCSFiles:Object.cs.12726", parentItem.DisplayName);
+                            return;
+                        default:
+                            break;
+                    }
                 }
             }
+            return;
         }
 
     }

--- a/DynamicGameAssets/Patches/ObjectPatcher.cs
+++ b/DynamicGameAssets/Patches/ObjectPatcher.cs
@@ -170,7 +170,6 @@ namespace DynamicGameAssets.Patches
                 string dga_parent_ID = __instance.modData["spacechase0.DynamicGameAssets/preserved-parent-ID"];
                 if (Mod.Find(dga_parent_ID).ToItem() is CustomObject parentItem)
                 {
-                    //Log.Debug($"Changing display name for preserved item with parent named {parentItem.DisplayName}");
                     switch (__instance.preserve.Value)
                     {
                         case SObject.PreserveType.Wine:


### PR DESCRIPTION
This adds two patches to support the correct display names for Wine, Juice, Pickles, and Jelly.
- Postfix on performObjectDropInAction in order to add modData to the heldItems to identify their parent, and correct set the price
- Postfix on loadDisplayName in order to read the modData and pass the correct display name to the relevant game functions