### PR TITLE
Adjusts MultiFertilizers for Custom Fertilizer compat

### DIFF
--- a/MultiFertilizer/Patches/CropPatcher.cs
+++ b/MultiFertilizer/Patches/CropPatcher.cs
@@ -32,8 +32,9 @@ namespace MultiFertilizer.Patches
         ** Private methods
         *********/
         /// <summary>The method to call before <see cref="Crop.harvest"/>.</summary>
-        private static void Before_Harvest(Crop __instance, int xTile, int yTile, HoeDirt soil, JunimoHarvester junimoHarvester)
+        private static void Before_Harvest(Crop __instance, int xTile, int yTile, HoeDirt soil, JunimoHarvester junimoHarvester, out int __state)
         {
+            __state = soil.fertilizer.Value;
             if (!soil.TryGetFertilizer(Mod.KeyFert, out FertilizerData fertilizer))
                 return;
 
@@ -41,9 +42,9 @@ namespace MultiFertilizer.Patches
         }
 
         /// <summary>The method to call after <see cref="Crop.harvest"/>.</summary>
-        private static void After_Harvest(Crop __instance, int xTile, int yTile, HoeDirt soil, JunimoHarvester junimoHarvester)
+        private static void After_Harvest(Crop __instance, int xTile, int yTile, HoeDirt soil, JunimoHarvester junimoHarvester, int __state)
         {
-            soil.fertilizer.Value = 0;
+            soil.fertilizer.Value = __state;
         }
     }
 }


### PR DESCRIPTION
Two major things:

1. In every case where the fertilizer value was previously reset to 0, save it in a __state instead.
2. Adjusts the draw transpiler a little - restores storing of the fertilizer value into local 2 (instead of....whatever was getting stored, I think this might have actually been causing me the AccessViolationExceptions) and just replaces the ldloc with a ldc_i4_1 to skip the branch. Then draws any custom fertilizer, if needed.