### PR TITLE
TV screen size is a float

### DIFF
--- a/DynamicGameAssets/PackData/FurniturePackData.cs
+++ b/DynamicGameAssets/PackData/FurniturePackData.cs
@@ -75,7 +75,7 @@ namespace DynamicGameAssets.PackData
 
         // TV specific
         public Vector2 ScreenPosition { get; set; }
-        public int ScreenSize { get; set; }
+        public float ScreenSize { get; set; }
 
         public bool ShouldSerializeScreenPositione() { return this.Type == FurnitureType.TV; }
         public bool ShouldSerializeScreenSize() { return this.Type == FurnitureType.TV; }


### PR DESCRIPTION
TV screen size can be a float, which allows for more fine-tuned adjustments. 
![image](https://user-images.githubusercontent.com/94934860/165390388-0b6b1158-c1e6-487f-a9a1-00ea2bbda569.png)
