### PR TITLE
Adding chair, bench, couch, and armchair as functional types with seats

### DIFF
--- a/DynamicGameAssets/Game/CustomBasicFurniture.cs
+++ b/DynamicGameAssets/Game/CustomBasicFurniture.cs
@@ -92,10 +92,13 @@ namespace DynamicGameAssets.Game
 
             if (Furniture.isDrawingLocationFurniture)
             {
-                if (this.HasSittingFarmers() && this.sourceRect.Right <= Furniture.furnitureFrontTexture.Width && this.sourceRect.Bottom <= Furniture.furnitureFrontTexture.Height)
+                if (this.HasSittingFarmers())
                 {
                     spriteBatch.Draw(currTex.Texture, Game1.GlobalToLocal(Game1.viewport, this.drawPosition + ((this.shakeTimer > 0) ? new Vector2(Game1.random.Next(-1, 2), Game1.random.Next(-1, 2)) : Vector2.Zero)), currTex.Rect, Color.White * alpha, 0f, Vector2.Zero, 4f, this.flipped ? SpriteEffects.FlipHorizontally : SpriteEffects.None, (float)(this.boundingBox.Value.Top + 16) / 10000f);
-                    spriteBatch.Draw(frontTex.Texture, Game1.GlobalToLocal(Game1.viewport, this.drawPosition + ((this.shakeTimer > 0) ? new Vector2(Game1.random.Next(-1, 2), Game1.random.Next(-1, 2)) : Vector2.Zero)), frontTex.Rect, Color.White * alpha, 0f, Vector2.Zero, 4f, this.flipped ? SpriteEffects.FlipHorizontally : SpriteEffects.None, (float)(this.boundingBox.Value.Bottom - 8) / 10000f);
+                    if (frontTex != null && this.sourceRect.Right <= Furniture.furnitureFrontTexture.Width && this.sourceRect.Bottom <= Furniture.furnitureFrontTexture.Height)
+                    {
+                        spriteBatch.Draw(frontTex.Texture, Game1.GlobalToLocal(Game1.viewport, this.drawPosition + ((this.shakeTimer > 0) ? new Vector2(Game1.random.Next(-1, 2), Game1.random.Next(-1, 2)) : Vector2.Zero)), frontTex.Rect, Color.White * alpha, 0f, Vector2.Zero, 4f, this.flipped ? SpriteEffects.FlipHorizontally : SpriteEffects.None, (float)(this.boundingBox.Value.Bottom - 8) / 10000f);
+                    }
                 }
                 else
                 {
@@ -192,12 +195,54 @@ namespace DynamicGameAssets.Game
 
         public override int GetSeatCapacity()
         {
+            if (this.GetCurrentConfiguration().Seats.Count == 0 && (this.furniture_type == 0 || this.furniture_type == 1 || this.furniture_type == 3))
+            {
+                return base.GetSeatCapacity();
+            }
+            if (this.GetCurrentConfiguration().Seats.Count == 0 && this.furniture_type == 2)
+            {
+                return this.defaultSourceRect.Width / 16 - 1;
+            }
             return this.GetCurrentConfiguration().Seats.Count;
         }
 
         public override List<Vector2> GetSeatPositions(bool ignore_offsets = false)
         {
+            if (this.GetCurrentConfiguration().Seats.Count == 0 && (this.furniture_type == 0 || this.furniture_type == 1 || this.furniture_type == 3))
+            {
+                return base.GetSeatPositions();
+            }
+
             var ret = new List<Vector2>();
+
+            if (this.GetCurrentConfiguration().Seats.Count == 0 && this.furniture_type == 2)
+            {
+                int width = this.defaultSourceRect.Width / 16 - 1;
+                if ((int)this.currentRotation == 0 || (int)this.currentRotation == 2)
+                {
+                    ret.Add(base.TileLocation + new Vector2(0.5f, 0f));
+                    for (int i = 1; i < width - 1; i++)
+                    {
+                        ret.Add(base.TileLocation + new Vector2((float)i + 0.5f, 0f));
+                    }
+                    ret.Add(base.TileLocation + new Vector2((float)(width - 1) + 0.5f, 0f));
+                }
+                else if ((int)this.currentRotation == 1)
+                {
+                    for (int k = 0; k < width; k++)
+                    {
+                        ret.Add(base.TileLocation + new Vector2(1f, k));
+                    }
+                }
+                else
+                {
+                    for (int j = 0; j < width; j++)
+                    {
+                        ret.Add(base.TileLocation + new Vector2(0f, j));
+                    }
+                }
+                return ret;
+            }
 
             foreach (var seat in this.GetCurrentConfiguration().Seats)
             {
@@ -209,6 +254,11 @@ namespace DynamicGameAssets.Game
 
         public int GetSittingDirection()
         {
+            if (this.GetCurrentConfiguration().Seats.Count == 0 && this.furniture_type == 0 || this.furniture_type == 1 || this.furniture_type == 2 || this.furniture_type == 3)
+            {
+                return base.GetSittingDirection();
+            }
+
             return this.GetCurrentConfiguration().SittingDirection == FurniturePackData.FurnitureConfiguration.SeatDirection.Any ?
                    Game1.player.FacingDirection : (int)this.GetCurrentConfiguration().SittingDirection;
         }

--- a/DynamicGameAssets/PackData/FurniturePackData.cs
+++ b/DynamicGameAssets/PackData/FurniturePackData.cs
@@ -63,7 +63,11 @@ namespace DynamicGameAssets.PackData
             TV,
             Lamp,
             Sconce,
-            Window
+            Window,
+            Chair,
+            Bench,
+            Couch,
+            Armchair
         }
 
         [DefaultValue(FurnitureType.Decoration)]
@@ -118,6 +122,10 @@ namespace DynamicGameAssets.PackData
                 FurnitureType.Lamp => Furniture.lamp,
                 FurnitureType.Sconce => Furniture.sconce,
                 FurnitureType.Window => Furniture.window,
+                FurnitureType.Chair => Furniture.chair,
+                FurnitureType.Bench => Furniture.bench,
+                FurnitureType.Couch => Furniture.couch,
+                FurnitureType.Armchair => Furniture.armchair,
                 _ => Furniture.other
             };
         }

--- a/DynamicGameAssets/docs/author-guide.md
+++ b/DynamicGameAssets/docs/author-guide.md
@@ -550,8 +550,8 @@ Furniture can be localized in the following keys: `"furniture.YourFurniture.name
 | Field | Type | Required or Default value | Description | Dynamic |
 | --- | --- | --- | --- | --- |
 | `ID` | `string` | Required | The ID of this furniture. | `false` |
-| `Type` | `Enum[Bed, Decoration, Dresser, Fireplace, FishTank, Lamp, Painting, Rug, Table, Sconce, TV, Window]` | Required | The type of this furniture. | `false` |
-| `Configurations` | `FurnitureConfiguration[]` | Required | The configurations for this funriture. It uses the first configuration by default, and the others after being rotated. (NOTE: Fish tanks, beds, and TVs may only support one configuration!) | (unknown, untested) |
+| `Type` | `Enum[Bed, Decoration, Dresser, Fireplace, FishTank, Lamp, Painting, Rug, Table, Sconce, TV, Window, Chair, Bench, Couch, Armchair]` | Required | The type of this furniture. | `false` |
+| `Configurations` | `FurnitureConfiguration[]` | Required | The configurations for this funriture. It uses the first configuration by default, and the others after being rotated. (NOTE: Fish tanks, beds, and TVs may only support one configuration! Chairs, benches, couches, and armchairs may only support 4 configurations.) | (unknown, untested) |
 | `ShowInCatalogue` | `bool` | Default: `true` | Whether the furniture shows up in the furniture catalogue. | (unknown, untested) |
 
 Certain furniture types have additional fields:
@@ -579,8 +579,8 @@ This should be an array of an an object called `FurnitureConfiguration`. A `Furn
 | `DisplaySize` | `Vector2` | Required | The display size of this furniture, in tiles. |
 | `CollisionHeight` | `int` | Required | How high from the bottom this furniture is solid. |
 | `Flipped` | `bool` | Default: `false` | If the texture is flipped or not. |
-| `Seats` | `Vector2[]` | Default: `null` | The list of seat positions, in tiles, if any. |
-| `SittingDirection` | `Enum[Any, Up, Down, Left, Right]` | Default: `"Any"` | The direction the seats face. |
+| `Seats` | `Vector2[]` | Default: `null` (Except for Chair, Bench, Couch, Armchair, where the default is the game defaults for those furniture types.) | The list of seat positions, in tiles, if any. |
+| `SittingDirection` | `Enum[Any, Up, Down, Left, Right]` | Default: `"Any"` (Except for Chair, Bench, Couch, Armchair, where the default is the game defaults for those furniture types.) | The direction the seats face. |
 | `TileProperties` | `Dictionary<Vector2, Dictionary<string, Dictionary<string, string>>>` | The tile properties to emulate for this furniture. It goes position -> layer -> property = value. (See example.)
 
 `Texture` and `FrontTexture` (if any) should have the same size: `DisplaySize` multiplied by 16 for both `X` and `Y`.


### PR DESCRIPTION
- Fixed game crash when FrontTexture not specified for a configuration with seats reported in #209 
- Adding in Chair, Bench, Couch, and Armchair as furniture types, with default seats matching the vanilla furniture seat positions and quantities