### PR TITLE
Add furniture category name overrides

### DIFF
--- a/DynamicGameAssets/Game/CustomBasicFurniture.cs
+++ b/DynamicGameAssets/Game/CustomBasicFurniture.cs
@@ -62,6 +62,11 @@ namespace DynamicGameAssets.Game
             return this.Data.Description;
         }
 
+        public override string getCategoryName()
+        {
+            return this.Data.CategoryTextOverride ?? base.getCategoryName();
+        }
+
         public override void drawInMenu(SpriteBatch spriteBatch, Vector2 location, float scaleSize, float transparency, float layerDepth, StackDrawType drawStackNumber, Color color, bool drawShadow)
         {
             spriteBatch.Draw(this.Data.GetTexture().Texture, location + new Vector2(32f, 32f), this.Data.GetTexture().Rect, color * transparency, 0f, new Vector2(this.defaultSourceRect.Width / 2, this.defaultSourceRect.Height / 2), 1f * this.getScaleSize() * scaleSize, SpriteEffects.None, layerDepth);

--- a/DynamicGameAssets/PackData/FurniturePackData.cs
+++ b/DynamicGameAssets/PackData/FurniturePackData.cs
@@ -81,7 +81,7 @@ namespace DynamicGameAssets.PackData
 
         // TV specific
         public Vector2 ScreenPosition { get; set; }
-        public int ScreenSize { get; set; }
+        public float ScreenSize { get; set; }
 
         public bool ShouldSerializeScreenPositione() { return this.Type == FurnitureType.TV; }
         public bool ShouldSerializeScreenSize() { return this.Type == FurnitureType.TV; }

--- a/DynamicGameAssets/PackData/FurniturePackData.cs
+++ b/DynamicGameAssets/PackData/FurniturePackData.cs
@@ -103,8 +103,6 @@ namespace DynamicGameAssets.PackData
         public string Description => this.pack.smapiPack.Translation.Get($"furniture.{this.ID}.description");
         [JsonIgnore]
         public string CategoryTextOverride => this.pack.smapiPack.Translation.Get($"furniture.{this.ID}.category").UsePlaceholder(false).ToString();
-        [DefaultValue(null)]
-        public Color? CategoryColorOverride { get; set; } = null;
 
         public int GetVanillaFurnitureType()
         {

--- a/DynamicGameAssets/PackData/FurniturePackData.cs
+++ b/DynamicGameAssets/PackData/FurniturePackData.cs
@@ -81,7 +81,7 @@ namespace DynamicGameAssets.PackData
 
         // TV specific
         public Vector2 ScreenPosition { get; set; }
-        public float ScreenSize { get; set; }
+        public int ScreenSize { get; set; }
 
         public bool ShouldSerializeScreenPositione() { return this.Type == FurnitureType.TV; }
         public bool ShouldSerializeScreenSize() { return this.Type == FurnitureType.TV; }
@@ -101,6 +101,10 @@ namespace DynamicGameAssets.PackData
         public string Name => this.pack.smapiPack.Translation.Get($"furniture.{this.ID}.name");
         [JsonIgnore]
         public string Description => this.pack.smapiPack.Translation.Get($"furniture.{this.ID}.description");
+        [JsonIgnore]
+        public string CategoryTextOverride => this.pack.smapiPack.Translation.Get($"furniture.{this.ID}.category").UsePlaceholder(false).ToString();
+        [DefaultValue(null)]
+        public Color? CategoryColorOverride { get; set; } = null;
 
         public int GetVanillaFurnitureType()
         {

--- a/DynamicGameAssets/docs/author-guide.md
+++ b/DynamicGameAssets/docs/author-guide.md
@@ -545,7 +545,7 @@ Example `DynamicFields` for a spring-only `CanGrowNow`:
 ## Furniture
 `$ItemType` - `"Furniture"`
 
-Furniture can be localized in the following keys: `"furniture.YourFurniture.name"` and `"furniture.YourFurniture.description"`.
+Furniture can be localized in the following keys: `"furniture.YourFurniture.name"` and `"furniture.YourFurniture.description"`. Additionally, `"furniture.YourFurniture.category"` can be specified for a category text override.
 
 | Field | Type | Required or Default value | Description | Dynamic |
 | --- | --- | --- | --- | --- |


### PR DESCRIPTION
Adds the option for furniture to specify category name overrides via the translation file. Possibly nice to have due to the fact that the placement restrictions for all DGA furniture are 2, making them all show up as "Decoration". If this isn't a desired change, no worries, it just seemed easy to add and like it might be nice. 