### PR TITLE
[GMCM] Minor fixes/polish for Scrollbar and Table elements.

### DIFF
--- a/SpaceShared/UI/Scrollbar.cs
+++ b/SpaceShared/UI/Scrollbar.cs
@@ -89,6 +89,10 @@ namespace SpaceShared.UI
             if (this.IsHidden())
                 return;
 
+            // Don't draw a scrollbar if scrolling is (currently) not possible.
+            if (this.MaxTopRow == 0)
+                return; 
+
             Rectangle back = new Rectangle((int)this.Position.X, (int)this.Position.Y, this.Width, this.Height);
             Vector2 front = new Vector2(back.X, back.Y + (this.Height - 40) * this.ScrollPercent);
 

--- a/SpaceShared/UI/Table.cs
+++ b/SpaceShared/UI/Table.cs
@@ -112,7 +112,12 @@ namespace SpaceShared.UI
                 }
                 topPx += this.FixedRowHeight ? this.RowHeight : maxElementHeight + RowPadding;
             }
-            this.ContentHeight = topPx;
+
+            if (topPx != this.ContentHeight) {
+                this.ContentHeight = topPx;
+                this.Scrollbar.Rows = this.ContentHeight / this.RowHeight;
+            }
+
             this.Scrollbar.Update();
         }
 
@@ -149,6 +154,7 @@ namespace SpaceShared.UI
 
             // draw background
             IClickableMenu.drawTextureBox(b, backgroundArea.X, backgroundArea.Y, backgroundArea.Width, backgroundArea.Height, Color.White);
+            b.Draw(Game1.menuTexture, contentArea, new Rectangle(64, 128, 64, 64), Color.White); // Smoother gradient for the content area.
 
             // draw table contents
             // This uses a scissor rectangle to clip content taller than one row that might be


### PR DESCRIPTION
### Summary:
- Avoid drawing a scrollbar on non-scrollable pages.
- Update the number of scrollbar rows when the table's content height changes.
- Make the table background texture less "blocky" (i.e. use a smoother gradient from MenuTiles).

### Video Demos:
- **Before** - https://streamable.com/rh965c
- **After** - https://streamable.com/ceryof

### GIF Demo:
![gmcm-table-scrollbar](https://user-images.githubusercontent.com/95021853/170845526-7cd1ab6d-39c5-44c3-9a61-da1bc44b0ca8.gif) 