### PR TITLE
fix the boots thing

### DIFF
--- a/JsonAssets/Data/BigCraftableData.cs
+++ b/JsonAssets/Data/BigCraftableData.cs
@@ -11,6 +11,7 @@ namespace JsonAssets.Data
 {
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = DiagnosticMessages.IsPublicApi)]
     [SuppressMessage("ReSharper", "InconsistentNaming", Justification = DiagnosticMessages.IsPublicApi)]
+    [DebuggerDisplay("name = {Name}, id = {Id}")]
     public class BigCraftableData : DataNeedsIdWithTexture, ITranslatableItem
     {
         /*********

--- a/JsonAssets/Data/BigCraftableData.cs
+++ b/JsonAssets/Data/BigCraftableData.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using JsonAssets.Framework;

--- a/JsonAssets/Data/BootsData.cs
+++ b/JsonAssets/Data/BootsData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using JsonAssets.Framework;

--- a/JsonAssets/Data/BootsData.cs
+++ b/JsonAssets/Data/BootsData.cs
@@ -10,6 +10,7 @@ namespace JsonAssets.Data
 {
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = DiagnosticMessages.IsPublicApi)]
     [SuppressMessage("ReSharper", "InconsistentNaming", Justification = DiagnosticMessages.IsPublicApi)]
+    [DebuggerDisplay("name = {Name}, id = {Id}")]
     public class BootsData : DataSeparateTextureIndex, ITranslatableItem
     {
         /*********

--- a/JsonAssets/Data/ClothingData.cs
+++ b/JsonAssets/Data/ClothingData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using JsonAssets.Framework;

--- a/JsonAssets/Data/ClothingData.cs
+++ b/JsonAssets/Data/ClothingData.cs
@@ -11,6 +11,7 @@ namespace JsonAssets.Data
 {
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = DiagnosticMessages.IsPublicApi)]
     [SuppressMessage("ReSharper", "InconsistentNaming", Justification = DiagnosticMessages.IsPublicApi)]
+    [DebuggerDisplay("name = {Name}, id = {Id}")]
     public class ClothingData : DataSeparateTextureIndex, ITranslatableItem
     {
         /*********

--- a/JsonAssets/Data/CropData.cs
+++ b/JsonAssets/Data/CropData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.Serialization;

--- a/JsonAssets/Data/CropData.cs
+++ b/JsonAssets/Data/CropData.cs
@@ -12,6 +12,7 @@ namespace JsonAssets.Data
 {
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = DiagnosticMessages.IsPublicApi)]
     [SuppressMessage("ReSharper", "InconsistentNaming", Justification = DiagnosticMessages.IsPublicApi)]
+    [DebuggerDisplay("name = {Name}, id = {Id}")]
     public class CropData : DataNeedsIdWithTexture
     {
         /*********

--- a/JsonAssets/Data/DataNeedsId.cs
+++ b/JsonAssets/Data/DataNeedsId.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace JsonAssets.Data
 {
     [DebuggerDisplay("name = {Name}, id = {Id}")]

--- a/JsonAssets/Data/DataNeedsId.cs
+++ b/JsonAssets/Data/DataNeedsId.cs
@@ -1,5 +1,6 @@
 namespace JsonAssets.Data
 {
+    [DebuggerDisplay("name = {Name}, id = {Id}")]
     public abstract class DataNeedsId
     {
         /*********

--- a/JsonAssets/Data/DataNeedsIdWithTexture.cs
+++ b/JsonAssets/Data/DataNeedsIdWithTexture.cs
@@ -8,6 +8,7 @@ namespace JsonAssets.Data
 {
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = DiagnosticMessages.IsPublicApi)]
     [SuppressMessage("ReSharper", "InconsistentNaming", Justification = DiagnosticMessages.IsPublicApi)]
+    [DebuggerDisplay("name = {Name}, id = {Id}")]
     public abstract class DataNeedsIdWithTexture : DataNeedsId
     {
         /*********

--- a/JsonAssets/Data/DataNeedsIdWithTexture.cs
+++ b/JsonAssets/Data/DataNeedsIdWithTexture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Xna.Framework.Graphics;
 using Newtonsoft.Json;

--- a/JsonAssets/Data/FenceData.cs
+++ b/JsonAssets/Data/FenceData.cs
@@ -10,6 +10,7 @@ namespace JsonAssets.Data
 {
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = DiagnosticMessages.IsPublicApi)]
     [SuppressMessage("ReSharper", "InconsistentNaming", Justification = DiagnosticMessages.IsPublicApi)]
+    [DebuggerDisplay("name = {Name}, id = {Id}")]
     public class FenceData : DataNeedsIdWithTexture, ITranslatableItem
     {
         /*********

--- a/JsonAssets/Data/FenceData.cs
+++ b/JsonAssets/Data/FenceData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using JsonAssets.Framework;

--- a/JsonAssets/Data/FruitTreeData.cs
+++ b/JsonAssets/Data/FruitTreeData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.Serialization;
 using JsonAssets.Framework;
 

--- a/JsonAssets/Data/FruitTreeData.cs
+++ b/JsonAssets/Data/FruitTreeData.cs
@@ -4,6 +4,7 @@ using JsonAssets.Framework;
 
 namespace JsonAssets.Data
 {
+    [DebuggerDisplay("name = {Name}, id = {Id}")]
     public class FruitTreeData : DataNeedsIdWithTexture
     {
         /*********

--- a/JsonAssets/Data/HatData.cs
+++ b/JsonAssets/Data/HatData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using JsonAssets.Framework;

--- a/JsonAssets/Data/HatData.cs
+++ b/JsonAssets/Data/HatData.cs
@@ -8,6 +8,7 @@ namespace JsonAssets.Data
 {
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = DiagnosticMessages.IsPublicApi)]
     [SuppressMessage("ReSharper", "InconsistentNaming", Justification = DiagnosticMessages.IsPublicApi)]
+    [DebuggerDisplay("name = {Name}, id = {Id}")]
     public class HatData : DataNeedsIdWithTexture, ITranslatableItem
     {
         /*********

--- a/JsonAssets/Data/ObjectData.cs
+++ b/JsonAssets/Data/ObjectData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using JsonAssets.Framework;

--- a/JsonAssets/Data/ObjectData.cs
+++ b/JsonAssets/Data/ObjectData.cs
@@ -12,6 +12,7 @@ namespace JsonAssets.Data
 {
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = DiagnosticMessages.IsPublicApi)]
     [SuppressMessage("ReSharper", "InconsistentNaming", Justification = DiagnosticMessages.IsPublicApi)]
+    [DebuggerDisplay("name = {Name}, id = {Id}")]
     public class ObjectData : DataNeedsIdWithTexture, ITranslatableItem
     {
         /*********

--- a/JsonAssets/Data/PantsData.cs
+++ b/JsonAssets/Data/PantsData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using JsonAssets.Framework;

--- a/JsonAssets/Data/PantsData.cs
+++ b/JsonAssets/Data/PantsData.cs
@@ -11,6 +11,7 @@ namespace JsonAssets.Data
 {
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = DiagnosticMessages.IsPublicApi)]
     [SuppressMessage("ReSharper", "InconsistentNaming", Justification = DiagnosticMessages.IsPublicApi)]
+    [DebuggerDisplay("name = {Name}, id = {Id}")]
     public class PantsData : DataSeparateTextureIndex, ITranslatableItem
     {
         /*********

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -100,7 +100,8 @@ namespace JsonAssets
                 new ItemPatcher(),
                 new ObjectPatcher(),
                 new RingPatcher(),
-                new ShopMenuPatcher()
+                new ShopMenuPatcher(),
+                new BootPatcher()
             );
         }
 

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -82,13 +82,13 @@ namespace JsonAssets
             helper.Content.AssetEditors.Add(this.Content1 = new ContentInjector1());
             helper.Content.AssetLoaders.Add(this.Content1);
 
-            TileSheetExtensions.RegisterExtendedTileSheet("Maps\\springobjects", 16);
-            TileSheetExtensions.RegisterExtendedTileSheet("TileSheets\\Craftables", 32);
-            TileSheetExtensions.RegisterExtendedTileSheet("TileSheets\\crops", 32);
-            TileSheetExtensions.RegisterExtendedTileSheet("TileSheets\\fruitTrees", 80);
-            TileSheetExtensions.RegisterExtendedTileSheet("Characters\\Farmer\\shirts", 32);
-            TileSheetExtensions.RegisterExtendedTileSheet("Characters\\Farmer\\pants", 688);
-            TileSheetExtensions.RegisterExtendedTileSheet("Characters\\Farmer\\hats", 80);
+            TileSheetExtensions.RegisterExtendedTileSheet(@"Maps\springobjects", 16);
+            TileSheetExtensions.RegisterExtendedTileSheet(@"TileSheets\Craftables", 32);
+            TileSheetExtensions.RegisterExtendedTileSheet(@"TileSheets\crops", 32);
+            TileSheetExtensions.RegisterExtendedTileSheet(@"TileSheets\fruitTrees", 80);
+            TileSheetExtensions.RegisterExtendedTileSheet(@"Characters\Farmer\shirts", 32);
+            TileSheetExtensions.RegisterExtendedTileSheet(@"Characters\Farmer\pants", 688);
+            TileSheetExtensions.RegisterExtendedTileSheet(@"Characters\Farmer\hats", 80);
 
             HarmonyPatcher.Apply(this,
                 new CropPatcher(),
@@ -122,7 +122,7 @@ namespace JsonAssets
             }
             foreach (var newId in newIds)
             {
-                if (ret.TryGetValue(newId.Key, out var pair))
+                if (ret.TryGetValue(newId.Key, out KeyValuePair<int, int> pair))
                     ret[newId.Key] = new KeyValuePair<int, int>(pair.Key, newId.Value);
                 else
                     ret.Add(newId.Key, new KeyValuePair<int, int>(-1, newId.Value));
@@ -224,10 +224,9 @@ namespace JsonAssets
 
                 this.ResetAtTitle();
             }
-
         }
 
-        private static readonly Regex NameToId = new("[^a-zA-Z0-9_.]");
+        private static readonly Regex NameToId = new("[^a-zA-Z0-9_.]", RegexOptions.Compiled|RegexOptions.ECMAScript);
 
         /// <summary>Load a folder as a Json Assets content pack.</summary>
         /// <param name="path">The absolute path to the content pack folder.</param>
@@ -1480,26 +1479,29 @@ namespace JsonAssets
                 this.OldHatIds = LoadDictionary<string, int>("ids-hats.json") ?? new Dictionary<string, int>();
                 this.OldWeaponIds = LoadDictionary<string, int>("ids-weapons.json") ?? new Dictionary<string, int>();
                 this.OldClothingIds = LoadDictionary<string, int>("ids-clothing.json") ?? new Dictionary<string, int>();
-                this.OldBootsIds = LoadDictionary<string, int>("ids-boots.json") ?? new Dictionary<string, int>();
+                //this.OldBootsIds = LoadDictionary<string, int>("ids-boots.json") ?? new Dictionary<string, int>();
 
-                Log.Verbose("OLD IDS START");
-                foreach (var id in this.OldObjectIds)
-                    Log.Verbose("\tObject " + id.Key + " = " + id.Value);
-                foreach (var id in this.OldCropIds)
-                    Log.Verbose("\tCrop " + id.Key + " = " + id.Value);
-                foreach (var id in this.OldFruitTreeIds)
-                    Log.Verbose("\tFruit Tree " + id.Key + " = " + id.Value);
-                foreach (var id in this.OldBigCraftableIds)
-                    Log.Verbose("\tBigCraftable " + id.Key + " = " + id.Value);
-                foreach (var id in this.OldHatIds)
-                    Log.Verbose("\tHat " + id.Key + " = " + id.Value);
-                foreach (var id in this.OldWeaponIds)
-                    Log.Verbose("\tWeapon " + id.Key + " = " + id.Value);
-                foreach (var id in this.OldClothingIds)
-                    Log.Verbose("\tClothing " + id.Key + " = " + id.Value);
-                foreach (var id in this.OldBootsIds)
-                    Log.Verbose("\tBoots " + id.Key + " = " + id.Value);
-                Log.Verbose("OLD IDS END");
+                if (this.Monitor.IsVerbose)
+                {
+                    Log.Verbose("OLD IDS START");
+                    foreach (var id in this.OldObjectIds)
+                        Log.Verbose("\tObject " + id.Key + " = " + id.Value);
+                    foreach (var id in this.OldCropIds)
+                        Log.Verbose("\tCrop " + id.Key + " = " + id.Value);
+                    foreach (var id in this.OldFruitTreeIds)
+                        Log.Verbose("\tFruit Tree " + id.Key + " = " + id.Value);
+                    foreach (var id in this.OldBigCraftableIds)
+                        Log.Verbose("\tBigCraftable " + id.Key + " = " + id.Value);
+                    foreach (var id in this.OldHatIds)
+                        Log.Verbose("\tHat " + id.Key + " = " + id.Value);
+                    foreach (var id in this.OldWeaponIds)
+                        Log.Verbose("\tWeapon " + id.Key + " = " + id.Value);
+                    foreach (var id in this.OldClothingIds)
+                        Log.Verbose("\tClothing " + id.Key + " = " + id.Value);
+                    //foreach (var id in this.OldBootsIds)
+                    //    Log.Verbose("\tBoots " + id.Key + " = " + id.Value);
+                    Log.Verbose("OLD IDS END");
+                }
             }
 
             // assign IDs
@@ -1561,6 +1563,7 @@ namespace JsonAssets
             File.WriteAllText(Path.Combine(Constants.CurrentSavePath, "JsonAssets", "ids-hats.json"), JsonConvert.SerializeObject(this.HatIds));
             File.WriteAllText(Path.Combine(Constants.CurrentSavePath, "JsonAssets", "ids-weapons.json"), JsonConvert.SerializeObject(this.WeaponIds));
             File.WriteAllText(Path.Combine(Constants.CurrentSavePath, "JsonAssets", "ids-clothing.json"), JsonConvert.SerializeObject(this.ClothingIds));
+            //File.WriteAllText(Path.Combine(Constants.CurrentSavePath, "JsonAssets", "ids-boots.json"), JsonConvert.SerializeObject(this.BootIds));
         }
 
         internal IList<ObjectData> MyRings = new List<ObjectData>();
@@ -1655,7 +1658,7 @@ namespace JsonAssets
         internal IDictionary<string, int> OldClothingIds;
 
         /// <summary>The custom boots' previously assigned IDs from the save data, indexed by item name.</summary>
-        internal IDictionary<string, int> OldBootsIds;
+        //internal IDictionary<string, int> OldBootsIds;
 
         /// <summary>The vanilla object IDs.</summary>
         internal ISet<int> VanillaObjectIds;
@@ -1781,35 +1784,32 @@ namespace JsonAssets
             int currId = starting;
             foreach (var d in data)
             {
-                if (d.Id == -1)
+                // handle name conflict
+                if (ids.TryGetValue(d.Name, out int prevId))
                 {
-                    // handle name conflict
-                    if (ids.TryGetValue(d.Name, out int prevId))
-                    {
-                        Log.Warn($"Found ID conflict: there are two custom '{type}' items with the name '{d.Name}'. This may have unintended consequences.");
-                        d.Id = prevId;
-                    }
+                    Log.Warn($"Found ID conflict: there are two custom '{type}' items with the name '{d.Name}'. This may have unintended consequences.");
+                    d.Id = prevId;
+                }
 
-                    // else assign new ID
-                    else
+                // else assign new ID
+                else
+                {
+                    Log.Verbose($"New ID: {d.Name} = {currId}");
+                    int id = currId++;
+                    if (type == "big-craftables")
                     {
-                        Log.Verbose($"New ID: {d.Name} = {currId}");
-                        int id = currId++;
-                        if (type == "big-craftables")
+                        while (bigSkip.Contains(id))
                         {
-                            while (bigSkip.Contains(id))
-                            {
-                                id = currId++;
-                            }
+                            id = currId++;
                         }
-
-                        ids.Add(d.Name, id);
-                        if (type == "objects" && d is ObjectData { IsColored: true })
-                            ++currId;
-                        else if (type == "big-craftables" && ((BigCraftableData)d).ReserveExtraIndexCount > 0)
-                            currId += ((BigCraftableData)d).ReserveExtraIndexCount;
-                        d.Id = ids[d.Name];
                     }
+
+                    ids.Add(d.Name, id);
+                    if (type == "objects" && d is ObjectData { IsColored: true })
+                        ++currId;
+                    else if (type == "big-craftables" && ((BigCraftableData)d).ReserveExtraIndexCount > 0)
+                        currId += ((BigCraftableData)d).ReserveExtraIndexCount;
+                    d.Id = ids[d.Name];
                 }
             }
 
@@ -1885,7 +1885,7 @@ namespace JsonAssets
 
                 // First, fix some stuff we broke in an earlier build by using .BundleData instead of the unlocalized version
                 // Copied from Game1.applySaveFix (case FixBotchedBundleData)
-                while (toks.Count > 4 && !int.TryParse(toks[toks.Count - 1], out _))
+                while (toks.Count > 4 && !int.TryParse(toks[^1], out _))
                 {
                     string lastValue = toks[toks.Count - 1];
                     if (char.IsDigit(lastValue[lastValue.Length - 1]) && lastValue.Contains(":") && lastValue.Contains("\\"))
@@ -1981,7 +1981,6 @@ namespace JsonAssets
 
                 case Boots boots:
                     return this.FixId(this.OldObjectIds, this.ObjectIds, boots.indexInTileSheet, this.VanillaObjectIds);
-
 
                 case SObject obj:
                     if (obj is Chest chest)
@@ -2516,7 +2515,8 @@ namespace JsonAssets
                         return false;
                     }
                 }
-                else return false;
+                else
+                    return false;
             }
             else
             {
@@ -2537,7 +2537,8 @@ namespace JsonAssets
                         return true;
                     }
                 }
-                else return false;
+                else
+                    return false;
             }
         }
 

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -1230,6 +1230,7 @@ namespace JsonAssets
             // When we go back to the title menu we need to reset things so things don't break when
             // going back to a save.
             this.ClearIds(out this.ObjectIds, this.Objects.ToList<DataNeedsId>());
+            this.ClearIds(out this.ObjectIds, this.Boots.ToList<DataNeedsId>());
             this.ClearIds(out this.CropIds, this.Crops.ToList<DataNeedsId>());
             this.ClearIds(out this.FruitTreeIds, this.FruitTrees.ToList<DataNeedsId>());
             this.ClearIds(out this.BigCraftableIds, this.BigCraftables.ToList<DataNeedsId>());

--- a/JsonAssets/Patches/BootPatcher.cs
+++ b/JsonAssets/Patches/BootPatcher.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using JsonAssets.Data;
+using Netcode;
+using Spacechase.Shared.Patching;
+using SpaceShared;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Objects;
+
+namespace JsonAssets.Patches;
+internal class BootPatcher : BasePatcher
+{
+
+    public override void Apply(Harmony harmony, IMonitor monitor)
+    {
+        harmony.Patch(
+            original: this.RequireMethod<Boots>("loadDisplayFields"),
+            finalizer: this.GetHarmonyMethod(nameof(FinalizeBootDisplayFields))
+            );
+    }
+
+    private static Exception? FinalizeBootDisplayFields(Boots __instance, Exception __exception)
+    {
+        if (__exception is not null)
+        {
+            Log.Warn($"{__instance.indexInTileSheet} corresponds to a pair of boots not found in Data/Boots!");
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
basically, the ids for boots weren't getting reset at return to title screen, so they weren't assigned new ids when the save was loaded again. This just makes it so assigning ids again is unconditional - I'm not sure why assigning ids were conditional in the first place.

(Apologies for the extra crud that made it into this commit).