### PR TITLE
Make JA ignore directories that start with a dot

### DIFF
--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -984,6 +984,8 @@ namespace JsonAssets
             {
                 foreach (DirectoryInfo dir in objectsDir.EnumerateDirectories())
                 {
+                    if (dir.Name.StartsWith('.'))
+                        continue;
                     string relativePath = $"Objects/{dir.Name}";
 
                     // load data
@@ -1006,6 +1008,8 @@ namespace JsonAssets
             {
                 foreach (DirectoryInfo dir in cropsDir.EnumerateDirectories())
                 {
+                    if (dir.Name.StartsWith('.'))
+                        continue;
                     string relativePath = $"Crops/{dir.Name}";
 
                     // load data
@@ -1028,6 +1032,8 @@ namespace JsonAssets
             {
                 foreach (DirectoryInfo dir in fruitTreesDir.EnumerateDirectories())
                 {
+                    if (dir.Name.StartsWith('.'))
+                        continue;
                     string relativePath = $"FruitTrees/{dir.Name}";
 
                     // load data
@@ -1047,6 +1053,8 @@ namespace JsonAssets
             {
                 foreach (DirectoryInfo dir in bigCraftablesDir.EnumerateDirectories())
                 {
+                    if (dir.Name.StartsWith('.'))
+                        continue;
                     string relativePath = $"BigCraftables/{dir.Name}";
 
                     // load data
@@ -1074,6 +1082,8 @@ namespace JsonAssets
             {
                 foreach (DirectoryInfo dir in hatsDir.EnumerateDirectories())
                 {
+                    if (dir.Name.StartsWith('.'))
+                        continue;
                     string relativePath = $"Hats/{dir.Name}";
 
                     // load data
@@ -1093,6 +1103,8 @@ namespace JsonAssets
             {
                 foreach (DirectoryInfo dir in weaponsDir.EnumerateDirectories())
                 {
+                    if (dir.Name.StartsWith('.'))
+                        continue;
                     string relativePath = $"Weapons/{dir.Name}";
 
                     // load data
@@ -1112,6 +1124,8 @@ namespace JsonAssets
             {
                 foreach (DirectoryInfo dir in shirtsDir.EnumerateDirectories())
                 {
+                    if (dir.Name.StartsWith('.'))
+                        continue;
                     string relativePath = $"Shirts/{dir.Name}";
 
                     // load data
@@ -1139,6 +1153,8 @@ namespace JsonAssets
             {
                 foreach (DirectoryInfo dir in pantsDir.EnumerateDirectories())
                 {
+                    if (dir.Name.StartsWith('.'))
+                        continue;
                     string relativePath = $"Pants/{dir.Name}";
 
                     // load data
@@ -1158,6 +1174,8 @@ namespace JsonAssets
             {
                 foreach (DirectoryInfo dir in tailoringDir.EnumerateDirectories())
                 {
+                    if (dir.Name.StartsWith('.'))
+                        continue;
                     string relativePath = $"Tailoring/{dir.Name}";
 
                     // load data
@@ -1175,6 +1193,8 @@ namespace JsonAssets
             {
                 foreach (DirectoryInfo dir in bootsDir.EnumerateDirectories())
                 {
+                    if (dir.Name.StartsWith('.'))
+                        continue;
                     string relativePath = $"Boots/{dir.Name}";
 
                     // load data
@@ -1194,6 +1214,8 @@ namespace JsonAssets
             {
                 foreach (DirectoryInfo dir in fencesDir.EnumerateDirectories())
                 {
+                    if (dir.Name.StartsWith('.'))
+                        continue;
                     string relativePath = $"Fences/{dir.Name}";
 
                     // load data
@@ -1213,6 +1235,8 @@ namespace JsonAssets
             {
                 foreach (DirectoryInfo dir in forgeDir.EnumerateDirectories())
                 {
+                    if (dir.Name.StartsWith('.'))
+                        continue;
                     string relativePath = $"Forge/{dir.Name}";
 
                     // load data


### PR DESCRIPTION
sometimes, to resolve conflicts between ja mods, users will need to remove an item or two from a pack. This makes it easier to do so.

![image](https://user-images.githubusercontent.com/94934860/171963232-74e24cc8-0ef5-46d3-a79f-02edcb495132.png)
