### PR TITLE
ignore ingredients that didn't map to anything.

### DIFF
--- a/JsonAssets/Data/BigCraftableRecipe.cs
+++ b/JsonAssets/Data/BigCraftableRecipe.cs
@@ -31,7 +31,12 @@ namespace JsonAssets.Data
         {
             string str = "";
             foreach (var ingredient in this.Ingredients)
-                str += Mod.instance.ResolveObjectId(ingredient.Object) + " " + ingredient.Count + " ";
+            {
+                int id = Mod.instance.ResolveObjectId(ingredient.Object);
+                if (id == 0)
+                    continue;
+                str += id + " " + ingredient.Count + " ";
+            }
             str = str.Substring(0, str.Length - 1);
             str += $"/what is this for?/{parent.Id} {this.ResultCount}/true/";
             if (this.SkillUnlockName?.Length > 0 && this.SkillUnlockLevel > 0)

--- a/JsonAssets/Data/ObjectRecipe.cs
+++ b/JsonAssets/Data/ObjectRecipe.cs
@@ -31,7 +31,12 @@ namespace JsonAssets.Data
         {
             string str = "";
             foreach (var ingredient in this.Ingredients)
-                str += Mod.instance.ResolveObjectId(ingredient.Object) + " " + ingredient.Count + " ";
+            {
+                int id = Mod.instance.ResolveObjectId(ingredient.Object);
+                if (id == 0)
+                    continue;
+                str += id + " " + ingredient.Count + " ";
+            }
             str = str.Substring(0, str.Length - 1);
             str += $"/what is this for?/{parent.Id} {this.ResultCount}/";
             if (parent.Category != ObjectCategory.Cooking)


### PR DESCRIPTION
Basically, if a recipe had two broken ingredients, the recipe builder would add the ingredient `0` twice, and then the cooking menu would crash because the same number was added twice.

There's probably more checking to do over duplicate ingredients, but this way "No idea what 'something' is" is less likely to crash the cooking menu.