### PR TITLE
Fixing the ability to harvest with mouse, mouse cursor display

### DIFF
--- a/DynamicGameAssets/Game/CustomCrop.cs
+++ b/DynamicGameAssets/Game/CustomCrop.cs
@@ -15,7 +15,7 @@ namespace DynamicGameAssets.Game
     [XmlType("Mods_DGACrop")]
     public partial class CustomCrop : Crop
     {
-        private CropPackData.PhaseData GetCurrentPhase()
+        public CropPackData.PhaseData GetCurrentPhase()
         {
             return this.Data.Phases.Count > this.currentPhase.Value ? this.Data.Phases[this.currentPhase.Value] : new CropPackData.PhaseData();
         }

--- a/DynamicGameAssets/Patches/CropPatcher.cs
+++ b/DynamicGameAssets/Patches/CropPatcher.cs
@@ -46,6 +46,10 @@ namespace DynamicGameAssets.Patches
                 original: this.RequireMethod<Crop>(nameof(Crop.drawWithOffset)),
                 prefix: this.GetHarmonyMethod(nameof(Before_DrawWithOffset))
             );
+            harmony.Patch(
+                original: this.RequireMethod<HoeDirt>(nameof(HoeDirt.readyForHarvest)),
+                postfix: this.GetHarmonyMethod(nameof(After_ReadyForHarvest))
+            );
         }
 
 
@@ -128,6 +132,18 @@ namespace DynamicGameAssets.Patches
             }
 
             return true;
+        }
+
+        /// <summary>The method to call after <see cref="HoeDirt.readyForHarvest"/>.</summary>
+        private static void After_ReadyForHarvest(HoeDirt __instance, ref bool __result)
+        {
+            if (__instance.crop != null && __instance.crop is CustomCrop custCrop) {
+                var currPhase = custCrop.GetCurrentPhase();
+                if (currPhase.HarvestedDrops.Count > 0)
+                {
+                    __result = true;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This does two things:
- Moves getCurrentPhase to public so that it can be accessed in the postfix
- Postfixes readyForHarvest in HoeDirt so that it checks the phases appropriately for DGA crops

This allows for a) the cursor to display the green plus appropriately for crops and b) the crops to be harvestable by mouse click instead of by keyboard button for action. 