### PR TITLE
Shuffle fiddling

### DIFF
--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -286,6 +286,15 @@ namespace JsonAssets
             if (!this.AssertHasName(obj, "object", source, translations))
                 return;
 
+            // check for duplicates
+            if (this.DupObjects.TryGetValue(obj.Name, out IManifest prevManifest))
+            {
+                Log.Error($"Duplicate object: {obj.Name} from {source.Name} will not be added, already added by {prevManifest.Name}!");
+                return;
+            }
+            else
+                this.DupObjects[obj.Name] = source;
+
             // save data
             this.Objects.Add(obj);
 
@@ -338,12 +347,6 @@ namespace JsonAssets
             if (obj.Category == ObjectCategory.Ring)
                 this.MyRings.Add(obj);
 
-            // check for duplicates
-            if (this.DupObjects.TryGetValue(obj.Name, out IManifest prevManifest))
-                Log.Error($"Duplicate object: {obj.Name} just added by {source.Name}, already added by {prevManifest.Name}!");
-            else
-                this.DupObjects[obj.Name] = source;
-
             // track added
             if (!this.ObjectsByContentPack.TryGetValue(source, out List<string> addedNames))
                 addedNames = this.ObjectsByContentPack[source] = new();
@@ -384,6 +387,7 @@ namespace JsonAssets
                 DescriptionLocalization = crop.SeedDescriptionLocalization,
                 TranslationKey = crop.SeedTranslationKey
             };
+
             this.PopulateTranslations(crop.Seed, translations);
 
             // validate
@@ -391,6 +395,15 @@ namespace JsonAssets
                 return;
             if (!this.AssertHasName(crop.Seed, "crop seed", source, translations, discriminator: $"crop: {crop.Name}", fieldName: nameof(crop.SeedName)))
                 return;
+
+            // check for duplicates
+            if (this.DupCrops.TryGetValue(crop.Name, out IManifest prevManifest))
+            {
+                Log.Error($"Duplicate crop: {crop.Name} by {source.Name} will not be added, already added by {prevManifest.Name}!");
+                return;
+            }
+            else
+                this.DupCrops[crop.Name] = source;
 
             // save crop data
             this.Crops.Add(crop);
@@ -450,12 +463,6 @@ namespace JsonAssets
                 }
             }
 
-            // check for duplicates
-            if (this.DupCrops.TryGetValue(crop.Name, out IManifest prevManifest))
-                Log.Error($"Duplicate crop: {crop.Name} just added by {source.Name}, already added by {prevManifest.Name}!");
-            else
-                this.DupCrops[crop.Name] = source;
-
             // save seed data
             this.Objects.Add(crop.Seed);
 
@@ -504,6 +511,15 @@ namespace JsonAssets
             };
             this.PopulateTranslations(tree.Sapling, translations);
 
+            // check for duplicates
+            if (this.DupFruitTrees.TryGetValue(tree.Name, out IManifest prevManifest))
+            {
+                Log.Error($"Duplicate fruit tree: {tree.Name} by {source.Name} will not be added, already added by {prevManifest.Name}!");
+                return;
+            }
+            else
+                this.DupFruitTrees[tree.Name] = source;
+
             // validate
             if (!this.AssertHasName(tree, "fruit tree", source, translations))
                 return;
@@ -536,12 +552,6 @@ namespace JsonAssets
                 }
             }
 
-            // check for duplicates
-            if (this.DupFruitTrees.TryGetValue(tree.Name, out IManifest prevManifest))
-                Log.Error($"Duplicate fruit tree: {tree.Name} just added by {source.Name}, already added by {prevManifest.Name}!");
-            else
-                this.DupFruitTrees[tree.Name] = source;
-
             if (!this.FruitTreesByContentPack.TryGetValue(source, out List<string> addedNames))
                 addedNames = this.FruitTreesByContentPack[source] = new List<string>();
             addedNames.Add(tree.Name);
@@ -568,6 +578,16 @@ namespace JsonAssets
             // validate
             if (!this.AssertHasName(craftable, "craftable", source, translations))
                 return;
+
+            // check for duplicates
+            if (this.DupBigCraftables.TryGetValue(craftable.Name, out IManifest prevManifest))
+            {
+                Log.Error($"Duplicate big craftable: {craftable.Name} by {source.Name} will not be added, already added by {prevManifest.Name}!");
+                return;
+            }
+            else
+                this.DupBigCraftables[craftable.Name] = source;
+
 
             // save data
             this.BigCraftables.Add(craftable);
@@ -616,12 +636,6 @@ namespace JsonAssets
                 }
             }
 
-            // check for duplicates
-            if (this.DupBigCraftables.TryGetValue(craftable.Name, out IManifest prevManifest))
-                Log.Error($"Duplicate big craftable: {craftable.Name} just added by {source.Name}, already added by {prevManifest.Name}!");
-            else
-                this.DupBigCraftables[craftable.Name] = source;
-
             if (!this.BigCraftablesByContentPack.TryGetValue(source, out List<string> addedNames))
                 addedNames = this.BigCraftablesByContentPack[source] = new();
             addedNames.Add(craftable.Name);
@@ -649,6 +663,15 @@ namespace JsonAssets
             if (!this.AssertHasName(hat, "hat", source, translations))
                 return;
 
+            // check for duplicates
+            if (this.DupHats.TryGetValue(hat.Name, out IManifest prevManifest))
+            {
+                Log.Error($"Duplicate hat: {hat.Name} by {source.Name} will not be added, already added by {prevManifest.Name}!");
+                return;
+            }
+            else
+                this.DupHats[hat.Name] = source;
+
             // save data
             this.Hats.Add(hat);
 
@@ -663,12 +686,6 @@ namespace JsonAssets
                     Object = () => new Hat(hat.Id)
                 });
             }
-
-            // check for duplicates
-            if (this.DupHats.TryGetValue(hat.Name, out IManifest prevManifest))
-                Log.Error($"Duplicate hat: {hat.Name} just added by {source.Name}, already added by {prevManifest.Name}!");
-            else
-                this.DupHats[hat.Name] = source;
 
             if (!this.HatsByContentPack.TryGetValue(source, out List<string> addedNames))
                 addedNames = this.HatsByContentPack[source] = new();
@@ -697,6 +714,15 @@ namespace JsonAssets
             if (!this.AssertHasName(weapon, "weapon", source, translations))
                 return;
 
+            // check for duplicates
+            if (this.DupWeapons.TryGetValue(weapon.Name, out IManifest prevManifest))
+            {
+                Log.Error($"Duplicate weapon: {weapon.Name} by {source.Name} will not be added, already added by {prevManifest.Name}!");
+                return;
+            }
+            else
+                this.DupWeapons[weapon.Name] = source;
+
             // save data
             this.Weapons.Add(weapon);
 
@@ -721,12 +747,6 @@ namespace JsonAssets
                     });
                 }
             }
-
-            // check for duplicates
-            if (this.DupWeapons.TryGetValue(weapon.Name, out IManifest prevManifest))
-                Log.Error($"Duplicate weapon: {weapon.Name} just added by {source.Name}, already added by {prevManifest.Name}!");
-            else
-                this.DupWeapons[weapon.Name] = source;
 
             if (!this.WeaponsByContentPack.TryGetValue(source, out List<string> addedNames))
                 addedNames = this.WeaponsByContentPack[source] = new();
@@ -755,14 +775,17 @@ namespace JsonAssets
             if (!this.AssertHasName(shirt, "shirt", source, translations))
                 return;
 
-            // save data
-            this.Shirts.Add(shirt);
-
             // check for duplicates
             if (this.DupShirts.TryGetValue(shirt.Name, out IManifest prevManifest))
-                Log.Error($"Duplicate shirt: {shirt.Name} just added by {source.Name}, already added by {prevManifest.Name}!");
+            {
+                Log.Error($"Duplicate shirt: {shirt.Name} by {source.Name} will not be added, already added by {prevManifest.Name}!");
+                return;
+            }
             else
                 this.DupShirts[shirt.Name] = source;
+
+            // save data
+            this.Shirts.Add(shirt);
 
             if (!this.ClothingByContentPack.TryGetValue(source, out List<string> addedNames))
                 addedNames = this.ClothingByContentPack[source] = new();
@@ -791,14 +814,17 @@ namespace JsonAssets
             if (!this.AssertHasName(pants, "pants", source, translations))
                 return;
 
-            // save data
-            this.Pants.Add(pants);
-
             // check for duplicates
             if (this.DupPants.TryGetValue(pants.Name, out IManifest prevManifest))
-                Log.Error($"Duplicate pants: {pants.Name} just added by {source.Name}, already added by {prevManifest.Name}!");
+            {
+                Log.Error($"Duplicate pants: {pants.Name} by {source.Name} will not be added, already added by {prevManifest.Name}!");
+                return;
+            }
             else
                 this.DupPants[pants.Name] = source;
+
+            // save data
+            this.Pants.Add(pants);
 
             if (!this.ClothingByContentPack.TryGetValue(source, out List<string> addedNames))
                 addedNames = this.ClothingByContentPack[source] = new();
@@ -837,6 +863,15 @@ namespace JsonAssets
             if (!this.AssertHasName(boots, "boots", source, translations))
                 return;
 
+            // check for duplicates
+            if (this.DupBoots.TryGetValue(boots.Name, out IManifest prevManifest))
+            {
+                Log.Error($"Duplicate boots: {boots.Name} by {source.Name} will not be added, already added by {prevManifest.Name}!");
+                return;
+            }
+            else
+                this.DupBoots[boots.Name] = source;
+
             // save data
             this.Boots.Add(boots);
 
@@ -862,12 +897,6 @@ namespace JsonAssets
                     });
                 }
             }
-
-            // check for duplicates
-            if (this.DupBoots.TryGetValue(boots.Name, out IManifest prevManifest))
-                Log.Error($"Duplicate boots: {boots.Name} just added by {source.Name}, already added by {prevManifest.Name}!");
-            else
-                this.DupBoots[boots.Name] = source;
 
             if (!this.BootsByContentPack.TryGetValue(source, out List<string> addedNames))
                 addedNames = this.BootsByContentPack[source] = new();

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -1865,91 +1865,97 @@ namespace JsonAssets
                 Log.Info("Reversing!");
             }
 
-            this.FixItemList(Game1.player.team.junimoChest);
+            
             this.FixCharacter(Game1.player);
-            foreach (var loc in Game1.locations)
-                this.FixLocation(loc);
 
             this.FixIdDict(Game1.player.basicShipped, removeUnshippable: true);
             this.FixIdDict(Game1.player.mineralsFound);
             this.FixIdDict(Game1.player.recipesCooked);
             this.FixIdDict2(Game1.player.archaeologyFound);
             this.FixIdDict2(Game1.player.fishCaught);
+            foreach (var dict in Game1.player.giftedItems.Values)
+                this.FixIdDict3(dict);
 
-            var bundleData = Game1.netWorldState.Value.GetUnlocalizedBundleData();
-            var bundleDataCopy = new Dictionary<string, string>(Game1.netWorldState.Value.GetUnlocalizedBundleData());
-
-            foreach (var entry in bundleDataCopy)
+            if (Context.IsMainPlayer)
             {
-                List<string> toks = new List<string>(entry.Value.Split('/'));
+                this.FixItemList(Game1.player.team.junimoChest);
+                foreach (var loc in Game1.locations)
+                    this.FixLocation(loc);
 
-                // First, fix some stuff we broke in an earlier build by using .BundleData instead of the unlocalized version
-                // Copied from Game1.applySaveFix (case FixBotchedBundleData)
-                while (toks.Count > 4 && !int.TryParse(toks[toks.Count - 1], out _))
-                {
-                    string lastValue = toks[toks.Count - 1];
-                    if (char.IsDigit(lastValue[lastValue.Length - 1]) && lastValue.Contains(":") && lastValue.Contains("\\"))
-                    {
-                        break;
-                    }
-                    toks.RemoveAt(toks.Count - 1);
-                }
+                var bundleData = Game1.netWorldState.Value.GetUnlocalizedBundleData();
+                var bundleDataCopy = new Dictionary<string, string>(Game1.netWorldState.Value.GetUnlocalizedBundleData());
 
-                // Then actually fix IDs
-                string[] toks1 = toks[1].Split(' ');
-                if (toks1[0] == "O")
+                foreach (var entry in bundleDataCopy)
                 {
-                    if (int.TryParse(toks1[1], out int oldId) && oldId != -1)
+                    List<string> toks = new List<string>(entry.Value.Split('/'));
+
+                    // First, fix some stuff we broke in an earlier build by using .BundleData instead of the unlocalized version
+                    // Copied from Game1.applySaveFix (case FixBotchedBundleData)
+                    while (toks.Count > 4 && !int.TryParse(toks[toks.Count - 1], out _))
                     {
-                        if (this.FixId(this.OldObjectIds, this.ObjectIds, ref oldId, this.VanillaObjectIds))
+                        string lastValue = toks[toks.Count - 1];
+                        if (char.IsDigit(lastValue[lastValue.Length - 1]) && lastValue.Contains(":") && lastValue.Contains("\\"))
                         {
-                            Log.Warn($"Bundle reward item missing ({entry.Key}, {oldId})! Probably broken now!");
-                            oldId = -1;
+                            break;
                         }
-                        else
+                        toks.RemoveAt(toks.Count - 1);
+                    }
+
+                    // Then actually fix IDs
+                    string[] toks1 = toks[1].Split(' ');
+                    if (toks1[0] == "O")
+                    {
+                        if (int.TryParse(toks1[1], out int oldId) && oldId != -1)
                         {
-                            toks1[1] = oldId.ToString();
+                            if (this.FixId(this.OldObjectIds, this.ObjectIds, ref oldId, this.VanillaObjectIds))
+                            {
+                                Log.Warn($"Bundle reward item missing ({entry.Key}, {oldId})! Probably broken now!");
+                                oldId = -1;
+                            }
+                            else
+                            {
+                                toks1[1] = oldId.ToString();
+                            }
                         }
                     }
-                }
-                else if (toks1[0] == "BO")
-                {
-                    if (int.TryParse(toks1[1], out int oldId) && oldId != -1)
+                    else if (toks1[0] == "BO")
                     {
-                        if (this.FixId(this.OldBigCraftableIds, this.BigCraftableIds, ref oldId, this.VanillaBigCraftableIds))
+                        if (int.TryParse(toks1[1], out int oldId) && oldId != -1)
                         {
-                            Log.Warn($"Bundle reward item missing ({entry.Key}, {oldId})! Probably broken now!");
-                            oldId = -1;
-                        }
-                        else
-                        {
-                            toks1[1] = oldId.ToString();
+                            if (this.FixId(this.OldBigCraftableIds, this.BigCraftableIds, ref oldId, this.VanillaBigCraftableIds))
+                            {
+                                Log.Warn($"Bundle reward item missing ({entry.Key}, {oldId})! Probably broken now!");
+                                oldId = -1;
+                            }
+                            else
+                            {
+                                toks1[1] = oldId.ToString();
+                            }
                         }
                     }
-                }
-                toks[1] = string.Join(" ", toks1);
-                string[] toks2 = toks[2].Split(' ');
-                for (int i = 0; i < toks2.Length; i += 3)
-                {
-                    if (int.TryParse(toks2[i], out int oldId) && oldId != -1)
+                    toks[1] = string.Join(" ", toks1);
+                    string[] toks2 = toks[2].Split(' ');
+                    for (int i = 0; i < toks2.Length; i += 3)
                     {
-                        if (this.FixId(this.OldObjectIds, this.ObjectIds, ref oldId, this.VanillaObjectIds))
+                        if (int.TryParse(toks2[i], out int oldId) && oldId != -1)
                         {
-                            Log.Warn($"Bundle item missing ({entry.Key}, {oldId})! Probably broken now!");
-                            oldId = -1;
-                        }
-                        else
-                        {
-                            toks2[i] = oldId.ToString();
+                            if (this.FixId(this.OldObjectIds, this.ObjectIds, ref oldId, this.VanillaObjectIds))
+                            {
+                                Log.Warn($"Bundle item missing ({entry.Key}, {oldId})! Probably broken now!");
+                                oldId = -1;
+                            }
+                            else
+                            {
+                                toks2[i] = oldId.ToString();
+                            }
                         }
                     }
+                    toks[2] = string.Join(" ", toks2);
+                    bundleData[entry.Key] = string.Join("/", toks);
                 }
-                toks[2] = string.Join(" ", toks2);
-                bundleData[entry.Key] = string.Join("/", toks);
+                // Fix bad bundle data
+                Game1.netWorldState.Value.SetBundleData(bundleData);
             }
-            // Fix bad bundle data
-
-            Game1.netWorldState.Value.SetBundleData(bundleData);
 
             if (!this.ReverseFixing)
                 this.Api.InvokeIdsFixed();
@@ -2397,7 +2403,7 @@ namespace JsonAssets
                             items[i] = null;
                         else if (this.FixId(this.OldWeaponIds, this.WeaponIds, weapon.currentParentTileIndex, this.VanillaWeaponIds))
                             items[i] = null;
-                        else if (this.FixId(this.OldWeaponIds, this.WeaponIds, weapon.currentParentTileIndex, this.VanillaWeaponIds))
+                        else if (this.FixId(this.OldWeaponIds, this.WeaponIds, weapon.indexOfMenuItemView, this.VanillaWeaponIds))
                             items[i] = null;
                     }
                 }
@@ -2481,6 +2487,38 @@ namespace JsonAssets
                 dict.Remove(entry);
             foreach (var entry in toAdd)
                 dict.Add(entry.Key, entry.Value);
+        }
+
+        private void FixIdDict3(SerializableDictionary<int, int> dict)
+        {
+            var toRemove = new List<int>();
+            var toAddOrUpdate = new Dictionary<int, int>();
+
+            foreach ((int key, int val) in dict)
+            {
+                if (this.VanillaObjectIds.Contains(key))
+                    continue;
+
+                // this is probably hellishly inefficient, building a lookup table is probably better
+                // but I'm being lazy rn ~atra.
+                KeyValuePair<string, int> item = this.OldObjectIds.FirstOrDefault(x => x.Value == key);
+                if (item.Key is not null) // default(kvp(string,int)) is (null,0)
+                {
+                    if (this.ObjectIds.TryGetValue(item.Key, out int newindex))
+                    {
+                        if (newindex != item.Value)
+                            toAddOrUpdate.Add(newindex, val);
+                    }
+                    else
+                    {
+                        toRemove.Add(key);
+                    }
+                }
+            }
+            foreach (int entry in toRemove)
+                dict.Remove(entry);
+            foreach ((int entry, int val) in toAddOrUpdate)
+                dict[entry] = val;
         }
 
         /// <summary>Fix item IDs contained by an item, including the item itself.</summary>

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -2719,7 +2719,7 @@ namespace JsonAssets
                         if (this.OldObjectIds.TryGetValue(item.Key, out int oldindex))
                         {
                             if (oldindex != item.Value)
-                                toAddOrUpdate.Add(oldindex, val)
+                                toAddOrUpdate.Add(oldindex, val);
                         }
                         else
                         {

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -1865,9 +1865,9 @@ namespace JsonAssets
                 Log.Info("Reversing!");
             }
 
-
             this.FixCharacter(Game1.player);
 
+            // <- does this get run for farmhands?
             this.FixIdDict(Game1.player.basicShipped, removeUnshippable: true);
             this.FixIdDict(Game1.player.mineralsFound);
             this.FixIdDict(Game1.player.recipesCooked);
@@ -1876,84 +1876,86 @@ namespace JsonAssets
             foreach (var dict in Game1.player.giftedItems.Values)
                 this.FixIdDict3(dict);
 
-
-            this.FixItemList(Game1.player.team.junimoChest);
-            foreach (var loc in Game1.locations)
-                this.FixLocation(loc);
-
-            var bundleData = Game1.netWorldState.Value.GetUnlocalizedBundleData();
-            var bundleDataCopy = new Dictionary<string, string>(Game1.netWorldState.Value.GetUnlocalizedBundleData());
-
-            foreach (var entry in bundleDataCopy)
+            if (Context.IsMainPlayer)
             {
-                List<string> toks = new List<string>(entry.Value.Split('/'));
+                this.FixItemList(Game1.player.team.junimoChest);
+                foreach (var loc in Game1.locations)
+                    this.FixLocation(loc);
 
-                // First, fix some stuff we broke in an earlier build by using .BundleData instead of the unlocalized version
-                // Copied from Game1.applySaveFix (case FixBotchedBundleData)
-                while (toks.Count > 4 && !int.TryParse(toks[toks.Count - 1], out _))
-                {
-                    string lastValue = toks[toks.Count - 1];
-                    if (char.IsDigit(lastValue[lastValue.Length - 1]) && lastValue.Contains(":") && lastValue.Contains("\\"))
-                    {
-                        break;
-                    }
-                    toks.RemoveAt(toks.Count - 1);
-                }
+                var bundleData = Game1.netWorldState.Value.GetUnlocalizedBundleData();
+                var bundleDataCopy = new Dictionary<string, string>(Game1.netWorldState.Value.GetUnlocalizedBundleData());
 
-                // Then actually fix IDs
-                string[] toks1 = toks[1].Split(' ');
-                if (toks1[0] == "O")
+                foreach (var entry in bundleDataCopy)
                 {
-                    if (int.TryParse(toks1[1], out int oldId) && oldId != -1)
+                    List<string> toks = new List<string>(entry.Value.Split('/'));
+
+                    // First, fix some stuff we broke in an earlier build by using .BundleData instead of the unlocalized version
+                    // Copied from Game1.applySaveFix (case FixBotchedBundleData)
+                    while (toks.Count > 4 && !int.TryParse(toks[toks.Count - 1], out _))
                     {
-                        if (this.FixId(this.OldObjectIds, this.ObjectIds, ref oldId, this.VanillaObjectIds))
+                        string lastValue = toks[toks.Count - 1];
+                        if (char.IsDigit(lastValue[lastValue.Length - 1]) && lastValue.Contains(":") && lastValue.Contains("\\"))
                         {
-                            Log.Warn($"Bundle reward item missing ({entry.Key}, {oldId})! Probably broken now!");
-                            oldId = -1;
+                            break;
                         }
-                        else
+                        toks.RemoveAt(toks.Count - 1);
+                    }
+
+                    // Then actually fix IDs
+                    string[] toks1 = toks[1].Split(' ');
+                    if (toks1[0] == "O")
+                    {
+                        if (int.TryParse(toks1[1], out int oldId) && oldId != -1)
                         {
-                            toks1[1] = oldId.ToString();
+                            if (this.FixId(this.OldObjectIds, this.ObjectIds, ref oldId, this.VanillaObjectIds))
+                            {
+                                Log.Warn($"Bundle reward item missing ({entry.Key}, {oldId})! Probably broken now!");
+                                oldId = -1;
+                            }
+                            else
+                            {
+                                toks1[1] = oldId.ToString();
+                            }
                         }
                     }
-                }
-                else if (toks1[0] == "BO")
-                {
-                    if (int.TryParse(toks1[1], out int oldId) && oldId != -1)
+                    else if (toks1[0] == "BO")
                     {
-                        if (this.FixId(this.OldBigCraftableIds, this.BigCraftableIds, ref oldId, this.VanillaBigCraftableIds))
+                        if (int.TryParse(toks1[1], out int oldId) && oldId != -1)
                         {
-                            Log.Warn($"Bundle reward item missing ({entry.Key}, {oldId})! Probably broken now!");
-                            oldId = -1;
-                        }
-                        else
-                        {
-                            toks1[1] = oldId.ToString();
+                            if (this.FixId(this.OldBigCraftableIds, this.BigCraftableIds, ref oldId, this.VanillaBigCraftableIds))
+                            {
+                                Log.Warn($"Bundle reward item missing ({entry.Key}, {oldId})! Probably broken now!");
+                                oldId = -1;
+                            }
+                            else
+                            {
+                                toks1[1] = oldId.ToString();
+                            }
                         }
                     }
-                }
-                toks[1] = string.Join(" ", toks1);
-                string[] toks2 = toks[2].Split(' ');
-                for (int i = 0; i < toks2.Length; i += 3)
-                {
-                    if (int.TryParse(toks2[i], out int oldId) && oldId != -1)
+                    toks[1] = string.Join(" ", toks1);
+                    string[] toks2 = toks[2].Split(' ');
+                    for (int i = 0; i < toks2.Length; i += 3)
                     {
-                        if (this.FixId(this.OldObjectIds, this.ObjectIds, ref oldId, this.VanillaObjectIds))
+                        if (int.TryParse(toks2[i], out int oldId) && oldId != -1)
                         {
-                            Log.Warn($"Bundle item missing ({entry.Key}, {oldId})! Probably broken now!");
-                            oldId = -1;
-                        }
-                        else
-                        {
-                            toks2[i] = oldId.ToString();
+                            if (this.FixId(this.OldObjectIds, this.ObjectIds, ref oldId, this.VanillaObjectIds))
+                            {
+                                Log.Warn($"Bundle item missing ({entry.Key}, {oldId})! Probably broken now!");
+                                oldId = -1;
+                            }
+                            else
+                            {
+                                toks2[i] = oldId.ToString();
+                            }
                         }
                     }
+                    toks[2] = string.Join(" ", toks2);
+                    bundleData[entry.Key] = string.Join("/", toks);
                 }
-                toks[2] = string.Join(" ", toks2);
-                bundleData[entry.Key] = string.Join("/", toks);
+                // Fix bad bundle data
+                Game1.netWorldState.Value.SetBundleData(bundleData);
             }
-            // Fix bad bundle data
-            Game1.netWorldState.Value.SetBundleData(bundleData);
 
             if (!this.ReverseFixing)
                 this.Api.InvokeIdsFixed();

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -2768,7 +2768,7 @@ namespace JsonAssets
                         if (this.OldObjectIds.TryGetValue(item.Key, out int oldindex))
                         {
                             if (oldindex != item.Value)
-                                addOrUpdate.Add(loc, item.Value);
+                                addOrUpdate.Add(loc, oldindex);
                         }
                         else
                         {
@@ -2784,7 +2784,7 @@ namespace JsonAssets
                         if (this.ObjectIds.TryGetValue(item.Key, out int newindex))
                         {
                             if (newindex != item.Value)
-                                addOrUpdate.Add(loc, item.Value);
+                                addOrUpdate.Add(loc, newindex);
                         }
                         else
                         {

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -2085,6 +2085,7 @@ namespace JsonAssets
         {
             foreach (var objective in order.objectives)
                 FixSpecialOrderObjective(objective);
+            FixItemList(order.donatedItems);
         }
 
         private void FixSpecialOrderObjective(OrderObjective objective)

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -2504,6 +2504,9 @@ namespace JsonAssets
                     if (this.FixId(this.OldObjectIds, this.ObjectIds, pond.neededItem.Value?.parentSheetIndex, this.VanillaObjectIds))
                         pond.neededItem.Value = null;
                     break;
+                case JunimoHut hut:
+                    this.FixItemList(hut.output.Value.items);
+                    break;
             }
         }
 
@@ -2627,7 +2630,7 @@ namespace JsonAssets
 
                         if (attached.GetType() != typeof(SObject) || attached.bigCraftable.Value)
                         {
-                            Log.Warn($"Unsupported attachment types! Let spacechase0 know he needs to support {attached.bigCraftable.Value} {attached}");
+                            Log.Warn($"Unsupported attachment types! Consider reporting {attached.bigCraftable.Value} {attached} to the mod page.");
                         }
                         else
                         {

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -2003,6 +2003,9 @@ namespace JsonAssets
             // fix museum donations
             this.FixVector2Dictionary(Game1.netWorldState.Value.MuseumPieces);
 
+            //fix returned items
+            this.FixItemList(Game1.player.team.returnedDonations);
+
             var bundleData = Game1.netWorldState.Value.GetUnlocalizedBundleData();
             var bundleDataCopy = new Dictionary<string, string>(Game1.netWorldState.Value.GetUnlocalizedBundleData());
 

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -2349,19 +2349,17 @@ namespace JsonAssets
                 loc.terrainFeatures.Remove(rem);
 
             toRemove.Clear();
-            foreach (var pair in loc.netObjects.Pairs)
+            foreach (var (key, obj) in loc.netObjects.Pairs)
             {
-                SObject obj = pair.Value;
                 if (this.FixItem(obj))
-                    toRemove.Add(pair.Key);
+                    toRemove.Add(key);
             }
             foreach (var rem in toRemove)
                 loc.objects.Remove(rem);
 
             toRemove.Clear();
-            foreach (var pair in loc.overlayObjects)
+            foreach (var (key, obj) in loc.overlayObjects)
             {
-                SObject obj = pair.Value;
                 if (obj is Chest chest)
                     this.FixItemList(chest.items);
                 else if (obj is Sign sign)
@@ -2374,12 +2372,12 @@ namespace JsonAssets
                     if (!obj.bigCraftable.Value)
                     {
                         if (this.FixId(this.OldObjectIds, this.ObjectIds, obj.parentSheetIndex, this.VanillaObjectIds))
-                            toRemove.Add(pair.Key);
+                            toRemove.Add(key);
                     }
                     else
                     {
                         if (this.FixId(this.OldBigCraftableIds, this.BigCraftableIds, obj.parentSheetIndex, this.VanillaBigCraftableIds))
-                            toRemove.Add(pair.Key);
+                            toRemove.Add(key);
                         else if (obj.ParentSheetIndex == 126 && obj.Quality != 0) // Alien rarecrow stores what ID is it is wearing here
                         {
                             obj.Quality--;
@@ -2434,7 +2432,7 @@ namespace JsonAssets
                     this.FixFarmAnimal(animal);
             }
 
-            foreach (var clump in loc.resourceClumps.Where(this.FixResourceClump))
+            foreach (var clump in loc.resourceClumps.Where(this.FixResourceClump).ToArray())
                 loc.resourceClumps.Remove(clump);
         }
 
@@ -2565,29 +2563,29 @@ namespace JsonAssets
             if (items is null)
                 return;
 
-            for (int i = 0; i < items.Count; ++i)
+            for (int i = items.Count - 1; i >= 0; i--)
             {
                 var item = items[i];
                 if (item == null)
-                    continue;
+                    items.RemoveAt(i);
                 if (item.GetType() == typeof(SObject))
                 {
                     var obj = item as SObject;
                     if (!obj.bigCraftable.Value)
                     {
                         if (this.FixId(this.OldObjectIds, this.ObjectIds, obj.parentSheetIndex, this.VanillaObjectIds))
-                            items[i] = null;
+                            items.RemoveAt(i);
                     }
                     else
                     {
                         if (this.FixId(this.OldBigCraftableIds, this.BigCraftableIds, obj.parentSheetIndex, this.VanillaBigCraftableIds))
-                            items[i] = null;
+                            items.RemoveAt(i);
                     }
                 }
                 else if (item is Hat hat)
                 {
                     if (this.FixId(this.OldHatIds, this.HatIds, hat.which, this.VanillaHatIds))
-                        items[i] = null;
+                        items.RemoveAt(i);
                 }
                 else if (item is Tool tool)
                 {
@@ -2612,27 +2610,27 @@ namespace JsonAssets
                     if (item is MeleeWeapon weapon)
                     {
                         if (this.FixId(this.OldWeaponIds, this.WeaponIds, weapon.initialParentTileIndex, this.VanillaWeaponIds))
-                            items[i] = null;
+                            items.RemoveAt(i);
                         else if (this.FixId(this.OldWeaponIds, this.WeaponIds, weapon.currentParentTileIndex, this.VanillaWeaponIds))
-                            items[i] = null;
+                            items.RemoveAt(i);
                         else if (this.FixId(this.OldWeaponIds, this.WeaponIds, weapon.indexOfMenuItemView, this.VanillaWeaponIds))
-                            items[i] = null;
+                            items.RemoveAt(i);
                     }
                 }
                 else if (item is Ring ring)
                 {
                     if (this.FixRing(ring))
-                        items[i] = null;
+                        items.RemoveAt(i);
                 }
                 else if (item is Clothing clothing)
                 {
                     if (this.FixId(this.OldClothingIds, this.ClothingIds, clothing.parentSheetIndex, this.VanillaClothingIds))
-                        items[i] = null;
+                        items.RemoveAt(i);
                 }
                 else if (item is Boots boots)
                 {
                     if (this.FixId(this.OldObjectIds, this.ObjectIds, boots.indexInTileSheet, this.VanillaObjectIds))
-                        items[i] = null;
+                        items.RemoveAt(i);
                     /*else
                         boots.reloadData();*/
                 }


### PR DESCRIPTION
Handles a couple of cases the previous shuffle code didn't. Moved some of the code around to account for multiplayer.

Primarily
1. Quests
2. Special orders
3. Anything referencing Game1.player moved to FixCharacter
4. the museum
5. items lost to death
6. weapon sprites
7. tailored dictionary
