### PR TITLE
allow Dropdowns to render outside the bounds of their enclosing Table

### DIFF
--- a/SpaceShared/UI/Container.cs
+++ b/SpaceShared/UI/Container.cs
@@ -26,7 +26,23 @@ namespace SpaceShared.UI
         /*********
         ** Accessors
         *********/
-        public Element RenderLast { get; set; }
+        private Element renderLast = null;
+        public Element RenderLast
+        {
+            get => renderLast;
+            set {
+                renderLast = value;
+                if (this.Parent is not null) {
+                    if (value is null) {
+                        if (this.Parent.RenderLast == this) {
+                            this.Parent.RenderLast = null;
+                        }
+                    } else {
+                        this.Parent.RenderLast = this;
+                    }
+                }
+            }
+        }
 
         public Element[] Children => this.ChildrenImpl.ToArray();
 

--- a/SpaceShared/UI/Table.cs
+++ b/SpaceShared/UI/Table.cs
@@ -159,6 +159,7 @@ namespace SpaceShared.UI
             // draw table contents
             // This uses a scissor rectangle to clip content taller than one row that might be
             // drawn past the bottom of the UI, like images or complex options.
+            Element? renderLast = null;
             this.InScissorRectangle(b, contentArea, contentBatch =>
             {
                 foreach (var row in this.Rows)
@@ -167,14 +168,15 @@ namespace SpaceShared.UI
                     {
                         if (this.IsElementOffScreen(element))
                             continue;
-                        if (element == this.RenderLast)
+                        if (element == this.RenderLast) {
+                            renderLast = element;
                             continue;
+                        }
                         element.Draw(contentBatch);
                     }
                 }
-
-                this.RenderLast?.Draw(contentBatch);
             });
+            renderLast?.Draw(b);
 
             this.Scrollbar.Draw(b);
         }


### PR DESCRIPTION
This is enabled by two changes: First, the Table draws the renderLast
element (if it exists and is visible) outside of its scissor rectangle.
Second, a Container with a renderLast element now also will register
itself to render last in its parent container (etc, recursively).