### PR TITLE
Add farming maps to Magic Photosynthesis spell

### DIFF
--- a/Magic/Framework/Spells/PhotosynthesisSpell.cs
+++ b/Magic/Framework/Spells/PhotosynthesisSpell.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Magic.Framework.Schools;
 using StardewValley;
+using StardewValley.Locations;
 using StardewValley.TerrainFeatures;
 using SObject = StardewValley.Object;
 
@@ -35,8 +37,45 @@ namespace Magic.Framework.Spells
             List<GameLocation> locs = new List<GameLocation>
             {
                 Game1.getLocationFromName("Farm"),
-                Game1.getLocationFromName("Greenhouse")
+                Game1.getLocationFromName("Greenhouse"),
+                Game1.getLocationFromName("IslandWest")
             };
+
+            List<GameLocation> mod_compat_locs = new List<GameLocation>
+            {
+                // Ridgeside Village:
+                Game1.getLocationFromName("Custom_Ridgeside_RSVGreenhouse1"),
+                Game1.getLocationFromName("Custom_Ridgeside_RSVGreenhouse2"),
+                Game1.getLocationFromName("Custom_Ridgeside_AguarCaveTemporary"),
+                Game1.getLocationFromName("Custom_Ridgeside_SummitFarm"),
+                // SVE:
+                Game1.getLocationFromName("Custom_GrandpasShedGreenhouse")
+            };
+            foreach (GameLocation loc in mod_compat_locs)
+            {
+                if (loc != null)
+                {
+                    locs.Add(loc);
+                }
+            }
+
+
+            foreach (GameLocation location in Game1.locations
+                .Concat(
+                    from location in Game1.locations.OfType<BuildableGameLocation>()
+                    from building in location.buildings
+                    where building.indoors.Value != null
+                    select building.indoors.Value
+                ))
+            {
+                if (location.IsGreenhouse)
+                {
+                    if (!locs.Contains(location))
+                    {
+                        locs.Add(location);
+                    }
+                }
+            }
             // TODO: API for other places to grow
             // TODO: Garden pots
             // Such as the SDM farms

--- a/Magic/Framework/Spells/PhotosynthesisSpell.cs
+++ b/Magic/Framework/Spells/PhotosynthesisSpell.cs
@@ -49,7 +49,8 @@ namespace Magic.Framework.Spells
                 Game1.getLocationFromName("Custom_Ridgeside_AguarCaveTemporary"),
                 Game1.getLocationFromName("Custom_Ridgeside_SummitFarm"),
                 // SVE:
-                Game1.getLocationFromName("Custom_GrandpasShedGreenhouse")
+                Game1.getLocationFromName("Custom_GrandpasShedGreenhouse"),
+                Game1.getLocationFromName("Custom_GrampletonFields")
             };
             foreach (GameLocation loc in mod_compat_locs)
             {
@@ -68,7 +69,7 @@ namespace Magic.Framework.Spells
                     select building.indoors.Value
                 ))
             {
-                if (location.IsGreenhouse)
+                if (location.IsGreenhouse || location.IsFarm)
                 {
                     if (!locs.Contains(location))
                     {


### PR DESCRIPTION
Added:

 - ginger island
 - Ridgeside summit farm, aguar cave, 2 greenhouses
 - SVE grandpa's shed
 - Also attempt to add all locations marked as IsGreenhouse=true

Fixes #247

I tested the SVE shed and ginger island farm to confirm those work