### PR TITLE
Update to Fix Issues With Additional Skills Mods

### DIFF
--- a/SpaceCore/Skills.cs
+++ b/SpaceCore/Skills.cs
@@ -156,7 +156,7 @@ namespace SpaceCore
             Skills.ValidateSkill(farmer, skillName);
 
             var skill = Skills.SkillsByName[skillName];
-            for (int i = skill.ExperienceCurve.Length - 1; i >= 0; --i)
+            for (int i = skill.ExperienceCurve.Length - 1; i > 0; --i)
             {
                 if (Skills.GetExperienceFor(farmer, skillName) >= skill.ExperienceCurve[i])
                 {


### PR DESCRIPTION
Without this fix, the game [throws exception ](https://imgur.com/a/IyxoiEw)with 'Magic' mod.
BUT, this bug appears, if installed both mods: 'Luck Skill' and 'Cooking Skill'.

With fix, there is no more problem.