### PR TITLE
Fix Enable Conditions

### DIFF
--- a/DynamicGameAssets/Mod.cs
+++ b/DynamicGameAssets/Mod.cs
@@ -269,7 +269,7 @@ namespace DynamicGameAssets
 
                                     if (key == opt.Key)
                                     {// this one we should handle ourselves
-                                        if (val != value)
+                                        if (!val.Equals(value, StringComparison.OrdinalIgnoreCase))
                                         { // fail the pack, we get to skip the rest of the work too.
                                             shouldreject = true;
                                             goto BreakBreak;

--- a/DynamicGameAssets/Mod.cs
+++ b/DynamicGameAssets/Mod.cs
@@ -254,9 +254,9 @@ namespace DynamicGameAssets
 
                 void DoEnableDisable(ContentIndexPackData parent)
                 {
-                    bool shouldreject = false;
                     foreach (var data in cp.Value.enableIndex[parent])
                     {
+                        bool shouldreject = false;
                         var conds = new Dictionary<string, string>();
                         if (data.EnableConditions != null)
                         {
@@ -305,14 +305,21 @@ BreakBreak:;
 
                         if (data is CommonPackData cdata && !cdata.Enabled && wasEnabled)
                         {
+                            Log.Trace($"Disabling item {cdata.ID}");
                             cdata.OnDisabled();
                         }
                         else if (data is ContentIndexPackData cidata)
                         {
                             if (!cidata.Enabled && wasEnabled)
+                            {
+                                Log.Trace($"Disabling content index {cidata.FilePath}");
                                 DoDisable(cidata);
+                            }
                             else
+                            {
+                                Log.Trace($"Enabling content index {cidata.FilePath}");
                                 DoEnableDisable(cidata);
+                            }
                         }
                     }
                 }

--- a/DynamicGameAssets/Mod.cs
+++ b/DynamicGameAssets/Mod.cs
@@ -269,9 +269,11 @@ namespace DynamicGameAssets
 
                                     if (key == opt.Key)
                                     {// this one we should handle ourselves
+                                        Log.Trace($"Evaluating pack config option {key} in EnableCondition");
                                         if (!val.Equals(value, StringComparison.OrdinalIgnoreCase))
                                         { // fail the pack, we get to skip the rest of the work too.
                                             shouldreject = true;
+                                            Log.Trace($"Rejecting condition {key} with value {val} because it's not equal to {value}");
                                             goto BreakBreak;
                                         }
                                         goto DontAdd;


### PR DESCRIPTION
- Fixes case sensitivity causing Boolean config options to be rejected because True != true
- Fixes `shouldreject` being initialized in the wrong place, causing multiple config option EnableConditions in the same content index to be incorrectly rejected
- Adds logging to Trace when config options are evaluated in EnableConditions, to help content pack authors debug
- Adds logging to Trace when content entries and content indexes are disabled, to help content pack authors debug