### PR TITLE
adds deprecation warnings to GMCM

### DIFF
--- a/GenericModConfigMenu/Framework/AssetManager.cs
+++ b/GenericModConfigMenu/Framework/AssetManager.cs
@@ -1,0 +1,22 @@
+#nullable enable
+
+using Microsoft.Xna.Framework.Graphics;
+
+using StardewModdingAPI.Events;
+using StardewModdingAPI.Utilities;
+
+namespace GenericModConfigMenu.Framework;
+internal static class AssetManager
+{
+    private const string BasePath = "Mods/GenericModConfigMenu";
+    internal static string ConfigButton { get; } = PathUtilities.NormalizeAssetName(BasePath + "/ConfigButton");
+    internal static string KeyboardButton { get; } = PathUtilities.NormalizeAssetName(BasePath + "/KeyboardButton");
+
+    internal static void Apply(AssetRequestedEventArgs e)
+    {
+        if (e.Name.IsEquivalentTo(ConfigButton))
+            e.LoadFromModFile<Texture2D>("assets/config-button.png", AssetLoadPriority.Exclusive);
+        else if (e.Name.IsEquivalentTo(KeyboardButton))
+            e.LoadFromModFile<Texture2D>("assets/keybindings-button.png", AssetLoadPriority.Exclusive);
+    }
+}

--- a/GenericModConfigMenu/Mod.cs
+++ b/GenericModConfigMenu/Mod.cs
@@ -196,7 +196,7 @@ namespace GenericModConfigMenu
 
         private void FiveTicksAfterGameLaunched(object sender, UpdateTickingEventArgs e)
         {
-            if (this.countdown-- < 5)
+            if (this.countdown-- < 0)
             {
                 this.SetupTitleMenuButton();
                 this.Helper.Events.GameLoop.UpdateTicking -= this.FiveTicksAfterGameLaunched;

--- a/GenericModConfigMenu/Mod.cs
+++ b/GenericModConfigMenu/Mod.cs
@@ -33,10 +33,6 @@ namespace GenericModConfigMenu
         /// <summary>Manages registered mod config menus.</summary>
         internal readonly ModConfigManager ConfigManager = new();
 
-        /// <summary>The mod API, if initialized.</summary>
-        private Api Api;
-
-
         /*********
         ** Accessors
         *********/
@@ -84,9 +80,9 @@ namespace GenericModConfigMenu
         }
 
         /// <inheritdoc />
-        public override object GetApi()
+        public override object GetApi(IModInfo mod)
         {
-            return this.Api ??= new Api(this.ConfigManager, mod => this.OpenModMenu(mod, page: null, listScrollRow: null));
+            return new Api(mod.Manifest, this.ConfigManager, mod => this.OpenModMenu(mod, page: null, listScrollRow: null), Log.Info);
         }
 
 

--- a/SpaceShared/UI/FloatBox.cs
+++ b/SpaceShared/UI/FloatBox.cs
@@ -16,9 +16,11 @@ namespace SpaceShared.UI
         *********/
         public float Value
         {
-            get => (this.String is "" or "-") ? 0 : float.Parse(this.String);
+            get => float.TryParse(this.String, out float value) ? value : 0f;
             set => this.String = value.ToString();
         }
+
+        public bool IsValid => float.TryParse(this.String, out _);
 
 
         /*********

--- a/SpaceShared/UI/Intbox.cs
+++ b/SpaceShared/UI/Intbox.cs
@@ -14,9 +14,11 @@ namespace SpaceShared.UI
         *********/
         public int Value
         {
-            get => (this.String is "" or "-") ? 0 : int.Parse(this.String);
+            get => int.TryParse(this.String, out int value) ? value : 0;
             set => this.String = value.ToString();
         }
+
+        public bool IsValid => int.TryParse(this.String, out _);
 
 
         /*********

--- a/SpaceShared/Util.cs
+++ b/SpaceShared/Util.cs
@@ -8,6 +8,9 @@ using StardewValley;
 
 namespace SpaceShared
 {
+
+#nullable enable
+
     internal static class Util
     {
         public static bool UsingMono => Type.GetType("Mono.Runtime") != null;
@@ -22,31 +25,42 @@ namespace SpaceShared
 
             // This is really bad. Pathos don't kill me.
             var modInfo = modRegistry.Get( packId );
-            if ( modInfo.GetType().GetProperty( "Mod" ).GetValue( modInfo ) is IMod mod )
-                return mod.Helper.Content.Load<Texture2D>( path );
-            else if ( modInfo.GetType().GetProperty( "ContentPack" ).GetValue( modInfo ) is IContentPack pack )
-                return pack.LoadAsset<Texture2D>( path );
+            if (modInfo is null)
+                return Game1.staminaRect;
+
+            if ( modInfo.GetType().GetProperty( "Mod" )?.GetValue( modInfo ) is IMod mod )
+                return mod.Helper.ModContent.Load<Texture2D>( path );
+            else if ( modInfo.GetType().GetProperty( "ContentPack" )?.GetValue( modInfo ) is IContentPack pack )
+                return pack.ModContent.Load<Texture2D>( path );
 
             return Game1.staminaRect;
         }
 
-        public static string FetchTexturePath( IModRegistry modRegistry, string modIdAndPath )
+        public static IAssetName? FetchTextureLocation(IModRegistry modRegistry, string modIdAndPath)
         {
-            if ( modIdAndPath == null || modIdAndPath.IndexOf( '/' ) == -1 )
+            if (modIdAndPath == null || modIdAndPath.IndexOf('/') == -1)
                 return null;
 
-            string packId = modIdAndPath.Substring( 0, modIdAndPath.IndexOf( '/' ) );
-            string path = modIdAndPath.Substring( modIdAndPath.IndexOf( '/' ) + 1 );
+            string packId = modIdAndPath.Substring(0, modIdAndPath.IndexOf('/'));
+            string path = modIdAndPath.Substring(modIdAndPath.IndexOf('/') + 1);
 
             // This is really bad. Pathos don't kill me.
-            var modInfo = modRegistry.Get( packId );
-            if ( modInfo.GetType().GetProperty( "Mod" ).GetValue( modInfo ) is IMod mod )
-                return mod.Helper.Content.GetActualAssetKey( path );
-            else if ( modInfo.GetType().GetProperty( "ContentPack" ).GetValue( modInfo ) is IContentPack pack )
-                return pack.GetActualAssetKey( path );
+            var modInfo = modRegistry.Get(packId);
+            if (modInfo is null)
+                return null;
+
+            if (modInfo.GetType().GetProperty("Mod")?.GetValue(modInfo) is IMod mod)
+                return mod.Helper.ModContent.GetInternalAssetName(path);
+            else if (modInfo.GetType().GetProperty("ContentPack")?.GetValue(modInfo) is IContentPack pack)
+                return pack.ModContent.GetInternalAssetName(path);
 
             return null;
         }
+
+        public static string? FetchTexturePath( IModRegistry modRegistry, string modIdAndPath )
+            => FetchTextureLocation(modRegistry, modIdAndPath)?.BaseName;
+
+#nullable restore
 
         public static Texture2D DoPaletteSwap(Texture2D baseTex, Texture2D from, Texture2D to)
         {


### PR DESCRIPTION
Methods marked obsolete will now log a warning about it.

(this one should be reviewed after the one that removes deprecated code from GMCM itself)