### PR TITLE
[Super Hopper] Push from own storage + junimo chest support

### DIFF
--- a/SuperHopper/Mod.cs
+++ b/SuperHopper/Mod.cs
@@ -103,8 +103,6 @@ namespace SuperHopper
                 Item item = hopperItems[i];
                 if (chestBelow.addItem(item) == null)
                     hopperItems.RemoveAt(i);
-                else
-                    return;
             }
 
             // check for top chest
@@ -119,8 +117,6 @@ namespace SuperHopper
                 Item item = chestAboveItems[i];
                 if (chestBelow.addItem(item) == null)
                     chestAboveItems.RemoveAt(i);
-                else
-                    return;
             }
         }
 

--- a/SuperHopper/Mod.cs
+++ b/SuperHopper/Mod.cs
@@ -107,7 +107,7 @@ namespace SuperHopper
                     return;
             }
 
-            // no chests to transfer
+            // check for top chest
             if (!location.objects.TryGetValue(hopper.TileLocation - new Vector2(0, 1), out SObject objAbove) || objAbove is not Chest chestAbove)
                 return;
 

--- a/SuperHopper/Mod.cs
+++ b/SuperHopper/Mod.cs
@@ -91,19 +91,36 @@ namespace SuperHopper
             if (!hopper.modData.ContainsKey(this.ModDataFlag))
                 hopper.modData[this.ModDataFlag] = "1";
 
+            // check for bottom chest
+            if (!location.objects.TryGetValue(hopper.TileLocation + new Vector2(0, 1), out SObject objBelow) || objBelow is not Chest chestBelow)
+                return;
+
+            // transfer current inventory if any
+            hopper.clearNulls();
+            var hopperItems = hopper.GetItemsForPlayer(hopper.owner.Value);
+            for (int i = hopperItems.Count - 1; i >= 0; i--)
+            {
+                Item item = hopperItems[i];
+                if (chestBelow.addItem(item) == null)
+                    hopperItems.RemoveAt(i);
+                else
+                    return;
+            }
+
             // no chests to transfer
             if (!location.objects.TryGetValue(hopper.TileLocation - new Vector2(0, 1), out SObject objAbove) || objAbove is not Chest chestAbove)
-                return;
-            if (!location.objects.TryGetValue(hopper.TileLocation + new Vector2(0, 1), out SObject objBelow) || objBelow is not Chest chestBelow)
                 return;
 
             // transfer items
             chestAbove.clearNulls();
-            for (int i = chestAbove.items.Count - 1; i >= 0; i--)
+            var chestAboveItems = chestAbove.GetItemsForPlayer(hopper.owner.Value);
+            for (int i = chestAboveItems.Count - 1; i >= 0; i--)
             {
-                Item item = chestAbove.items[i];
+                Item item = chestAboveItems[i];
                 if (chestBelow.addItem(item) == null)
-                    chestAbove.items.RemoveAt(i);
+                    chestAboveItems.RemoveAt(i);
+                else
+                    return;
             }
         }
 


### PR DESCRIPTION
This PR allows super hoppers to:

- Push their own contents (like vanilla hoppers, otherwise they behave mostly like regular chests)
- Push contents from junimo chests

In theory, this could also support other kinds of modded chests, assuming they return their own inventories though `Chest.GetItemsForPlayer(long)`. The hopper's owner is passed into `GetItemsForPlayer`, which doesn't seem to be relevant for junimo chests even in multiplayer since players seem to share the same junimo chest inventory, but might be useful for any future modded chests.