### PR TITLE
[Spacecore] Allows Custom skills to add recipes on the levelup screen

### DIFF
--- a/SpaceCore/Skills.cs
+++ b/SpaceCore/Skills.cs
@@ -76,6 +76,17 @@ namespace SpaceCore
 
             public Color ExperienceBarColor { get; set; }
 
+            public virtual IDictionary<int, IList<string>> GetSkillLevelUpCraftingRecipes(int level)
+            {
+                return new Dictionary<int, IList<string>>();
+            }
+
+            public virtual IDictionary<int, IList<string>> GetSkillLevelUpCookingRecipes(int level)
+            {
+                return new Dictionary<int, IList<string>>();
+            }
+
+
             public virtual List<string> GetExtraLevelUpInfo(int level)
             {
                 return new();


### PR DESCRIPTION
This PR makes it so custom skills can override these new virtual methods in `SpaceCore.Skills.Skill`
```
            public virtual IDictionary<int, IList<string>> GetSkillLevelUpCraftingRecipes(int level)
            {
                return new Dictionary<int, IList<string>>();
            }

            public virtual IDictionary<int, IList<string>> GetSkillLevelUpCookingRecipes(int level)
            {
                return new Dictionary<int, IList<string>>();
            }
```

`SkillLevelUpMenu` will then add these recipes to `this.newCraftingRecipes` through `GetCraftingRecipesForLevel(skill, level)` and `GetCraftingRecipesForLevel(skill, level)`. Allowing people who make custom skill not have to use reflection or events to modify `SkillLevelUpMenu` to display custom recipes. 
