### PR TITLE
Fix for mobile platform

### DIFF
--- a/SpaceCore/Patches/Game1Patcher.cs
+++ b/SpaceCore/Patches/Game1Patcher.cs
@@ -45,7 +45,7 @@ namespace SpaceCore.Patches
             harmony.Patch(
                 original: Constants.TargetPlatform != GamePlatform.Android
                     ? this.RequireMethod<Game1>(nameof(Game1.warpFarmer), new[] { typeof(LocationRequest), typeof(int), typeof(int), typeof(int) })
-                    : this.RequireMethod<Game1>(nameof(Game1.warpFarmer), new[] { typeof(LocationRequest), typeof(int), typeof(int), typeof(int), typeof(bool), typeof(bool) }),
+                    : this.RequireMethod<Game1>(nameof(Game1.warpFarmer), new[] { typeof(LocationRequest), typeof(int), typeof(int), typeof(int), typeof(bool)}),
                 prefix: this.GetHarmonyMethod(nameof(Before_WarpFarmer))
             );
 

--- a/SpaceCore/Patches/GameLocationPatcher.cs
+++ b/SpaceCore/Patches/GameLocationPatcher.cs
@@ -31,11 +31,22 @@ namespace SpaceCore.Patches
                 transpiler: this.GetHarmonyMethod(nameof(Transpile_PerformAction), after: "DaLion.ImmersiveProfessions")
             );
 
-            harmony.Patch(
-                original: this.RequireMethod<GameLocation>(nameof(GameLocation.answerDialogueAction)),
-                postfix: this.GetHarmonyMethod(nameof(After_AnswerDialogueAction)),
-                transpiler: this.GetHarmonyMethod(nameof(Transpile_AnswerDialogueAction), after: "DaLion.ImmersiveProfessions")
-            );
+            if (Constants.TargetPlatform != GamePlatform.Android)
+            {
+                harmony.Patch(
+                    original: this.RequireMethod<GameLocation>(nameof(GameLocation.answerDialogueAction)),
+                    postfix: this.GetHarmonyMethod(nameof(After_AnswerDialogueAction)),
+                    transpiler: this.GetHarmonyMethod(nameof(Transpile_AnswerDialogueAction), after: "DaLion.ImmersiveProfessions")
+                );
+            }
+            else
+            {
+                harmony.Patch(
+                    original: this.RequireMethod<GameLocation>(nameof(GameLocation.answerDialogueAction)),
+                    postfix: this.GetHarmonyMethod(nameof(After_AnswerDialogueAction)),
+                    transpiler: this.GetHarmonyMethod(nameof(GameLocationPatcher.Transpile_AnswerDialogueActionMobile), after: "DaLion.ImmersiveProfessions")
+                );
+            }
 
             harmony.Patch(
                 original: this.RequireMethod<GameLocation>(nameof(GameLocation.performTouchAction)),
@@ -100,6 +111,34 @@ namespace SpaceCore.Patches
                 if (!isPatched && CodeInstructionExtensions.Is(codes[i + 3], OpCodes.Ldstr, "Strings\\Locations:Sewer_DogStatueCancel"))
                 {
                     ret.Add(new CodeInstruction(OpCodes.Ldloc_1).WithLabels(codes[i].labels));
+                    ret.Add(new CodeInstruction(OpCodes.Call, PatchHelper.RequireMethod<Skills>(nameof(Skills.GetRespecCustomResponses))));
+                    ret.Add(new CodeInstruction(OpCodes.Call, PatchHelper.RequireMethod<List<Response>>(nameof(List<Response>.AddRange))));
+                    codes[i].labels.Clear();
+
+                    isPatched = true;
+                }
+                ret.Add(codes[i]);
+            }
+
+            return ret;
+        }
+
+
+        private static IEnumerable<CodeInstruction> Transpile_AnswerDialogueActionMobile(ILGenerator gen, MethodBase original, IEnumerable<CodeInstruction> insns)
+        {
+            List<CodeInstruction> ret = new List<CodeInstruction>();
+            var codes = new List<CodeInstruction>(insns);
+            LocalBuilder listLocal = null;
+            bool isPatched = false;
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (listLocal == null && codes[i].opcode == OpCodes.Ldloc_S && (codes[i].operand as LocalBuilder).LocalType == typeof(List<Response>))
+                {
+                    listLocal = codes[i].operand as LocalBuilder;
+                }
+                if (!isPatched && CodeInstructionExtensions.Is(codes[i + 3], OpCodes.Ldstr, "Strings\\Locations:Sewer_DogStatueCancel"))
+                {
+                    ret.Add(new CodeInstruction(OpCodes.Ldloc_S, listLocal).WithLabels(codes[i].labels));
                     ret.Add(new CodeInstruction(OpCodes.Call, PatchHelper.RequireMethod<Skills>(nameof(Skills.GetRespecCustomResponses))));
                     ret.Add(new CodeInstruction(OpCodes.Call, PatchHelper.RequireMethod<List<Response>>(nameof(List<Response>.AddRange))));
                     codes[i].labels.Clear();

--- a/SpaceCore/Patches/SaveGamePatcher.cs
+++ b/SpaceCore/Patches/SaveGamePatcher.cs
@@ -407,6 +407,9 @@ namespace SpaceCore.Patches
             SaveGamePatcher.FindAndRemoveModNodes(doc, modNodes, "/1"); // <?xml ... ?> is /0
 
             doc.WriteContentTo(origWriter);
+            // To fix serialize bug in mobile platform
+            if (Constants.TargetPlatform == GamePlatform.Android)
+                origWriter.Flush();
             string filename = serializer == SaveGame.farmerSerializer
                 ? SaveGamePatcher.SerializerManager.FarmerFilename
                 : SaveGamePatcher.SerializerManager.Filename;


### PR DESCRIPTION
SDV mobile platform changes:
1. `CraftingPage.layoutRecipes`  ->  `MobileCraftingPage.setupRecipes`
2. `Game1.warpFarmer` signature
3. `GameLocation.answerDialogueAction` , `response` local variable's position changed
4. SerializeProxy, the vanilla save logic has a bug that it dit not flush writer before retrieve MemoryStream