### PR TITLE
Fix GenericModConfigMenu for mobile

### DIFF
--- a/SpaceShared/UI/Dropdown.cs
+++ b/SpaceShared/UI/Dropdown.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
+using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Menus;
 
@@ -77,14 +78,29 @@ namespace SpaceShared.UI
             if (this.Dropped)
             {
                 //if (Mouse.GetState().LeftButton == ButtonState.Released)
-                if ((Mouse.GetState().LeftButton == ButtonState.Pressed && Game1.oldMouseState.LeftButton == ButtonState.Released ||
-                     Game1.input.GetGamePadState().Buttons.A == ButtonState.Pressed && Game1.oldPadState.Buttons.A == ButtonState.Released)
-                    && !justClicked)
+                if (Constants.TargetPlatform != GamePlatform.Android)
                 {
-                    Game1.playSound("drumkit6");
-                    this.Dropped = false;
-                    if (this.Parent.RenderLast == this)
-                        this.Parent.RenderLast = null;
+                    if ((Mouse.GetState().LeftButton == ButtonState.Pressed && Game1.oldMouseState.LeftButton == ButtonState.Released ||
+                         Game1.input.GetGamePadState().Buttons.A == ButtonState.Pressed && Game1.oldPadState.Buttons.A == ButtonState.Released)
+                        && !justClicked)
+                    {
+                        Game1.playSound("drumkit6");
+                        this.Dropped = false;
+                        if (this.Parent.RenderLast == this)
+                            this.Parent.RenderLast = null;
+                    }
+                }
+                else
+                {
+                    if ((Game1.input.GetMouseState().LeftButton == ButtonState.Pressed && Game1.oldMouseState.LeftButton == ButtonState.Released ||
+                         Game1.input.GetGamePadState().Buttons.A == ButtonState.Pressed && Game1.oldPadState.Buttons.A == ButtonState.Released)
+                        && !justClicked)
+                    {
+                        Game1.playSound("drumkit6");
+                        this.Dropped = false;
+                        if (this.Parent.RenderLast == this)
+                            this.Parent.RenderLast = null;
+                    }
                 }
 
                 int tall = Math.Min(this.MaxValuesAtOnce, this.Choices.Length - this.ActivePosition) * this.Height;

--- a/SpaceShared/UI/Scrollbar.cs
+++ b/SpaceShared/UI/Scrollbar.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using SpaceShared;
+using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Menus;
 
@@ -72,8 +73,17 @@ namespace SpaceShared.UI
 
             if (this.Clicked)
                 this.DragScroll = true;
-            if (this.DragScroll && Mouse.GetState().LeftButton == ButtonState.Released)
-                this.DragScroll = false;
+            if (Constants.TargetPlatform != GamePlatform.Android)
+            {
+                if (this.DragScroll && Mouse.GetState().LeftButton == ButtonState.Released)
+                    this.DragScroll = false;
+            }
+            else
+            {
+                if (this.DragScroll && Game1.input.GetMouseState().LeftButton == ButtonState.Released)
+                    this.DragScroll = false;
+            }
+
 
             if (this.DragScroll)
             {
@@ -91,7 +101,7 @@ namespace SpaceShared.UI
 
             // Don't draw a scrollbar if scrolling is (currently) not possible.
             if (this.MaxTopRow == 0)
-                return; 
+                return;
 
             Rectangle back = new Rectangle((int)this.Position.X, (int)this.Position.Y, this.Width, this.Height);
             Vector2 front = new Vector2(back.X, back.Y + (this.Height - 40) * this.ScrollPercent);

--- a/SpaceShared/UI/Slider.cs
+++ b/SpaceShared/UI/Slider.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using SpaceShared;
+using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Menus;
 
@@ -66,8 +67,17 @@ namespace SpaceShared.UI
 
             if (this.Clicked)
                 this.Dragging = true;
-            if (Mouse.GetState().LeftButton == ButtonState.Released && Game1.input.GetGamePadState().Buttons.A == ButtonState.Released)
-                this.Dragging = false;
+            if (Constants.TargetPlatform != GamePlatform.Android)
+            {
+                if (Mouse.GetState().LeftButton == ButtonState.Released && Game1.input.GetGamePadState().Buttons.A == ButtonState.Released)
+                    this.Dragging = false;
+            }
+            else
+            {
+                if (Game1.input.GetMouseState().LeftButton == ButtonState.Released && Game1.input.GetGamePadState().Buttons.A == ButtonState.Released)
+                    this.Dragging = false;
+            }
+
 
             if (this.Dragging)
             {


### PR DESCRIPTION
1. `Mouse.GetState().LeftButton` does not work in mobile platform, use `Game1.input.GetMouseState().LeftButton` instead