### PR TITLE
added null check to FixItem, specifically when fixing weapon ids

### DIFF
--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -1643,10 +1643,7 @@ namespace JsonAssets
                         weapon.ItemId = this.OldWeaponIds[weapon.ItemId].FixIdJA();
                     // If the weapon appearance is null, break early
                     if (weapon.appearance.Value is null)
-                    {
-                        Log.Trace($"{weapon.Name} appearance is null");
                         break;
-                    }
                     if (this.OldWeaponIds.ContainsKey(weapon.appearance.Value))
                         weapon.appearance.Value = this.OldWeaponIds[weapon.appearance.Value].FixIdJA();
                     break;

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -115,7 +115,7 @@ namespace JsonAssets
         private bool FirstTick = true;
         private void OnTick(object sender, UpdateTickedEventArgs e)
         {
-            // This needs to run after GameLaunched, because of the event 
+            // This needs to run after GameLaunched, because of the event
             if (this.FirstTick)
             {
                 this.FirstTick = false;
@@ -1534,7 +1534,7 @@ namespace JsonAssets
         {
             SpaceUtility.iterateAllItems(this.FixItem);
             SpaceUtility.iterateAllTerrainFeatures(this.FixTerrainFeature);
-            foreach ( var loc in Game1.locations )
+            foreach (var loc in Game1.locations)
             {
                 foreach (var building in loc.buildings)
                     FixBuilding(building);
@@ -1641,6 +1641,12 @@ namespace JsonAssets
                 case MeleeWeapon weapon:
                     if (this.OldWeaponIds.ContainsKey(weapon.ItemId))
                         weapon.ItemId = this.OldWeaponIds[weapon.ItemId].FixIdJA();
+                    // If the weapon appearance is null, break early
+                    if (weapon.appearance.Value is null)
+                    {
+                        Log.Trace($"{weapon.Name} appearance is null");
+                        break;
+                    }
                     if (this.OldWeaponIds.ContainsKey(weapon.appearance.Value))
                         weapon.appearance.Value = this.OldWeaponIds[weapon.appearance.Value].FixIdJA();
                     break;
@@ -1662,7 +1668,7 @@ namespace JsonAssets
                     if (this.OldClothingIds.ContainsKey(clothing.ItemId))
                         clothing.ItemId = this.OldClothingIds[clothing.ItemId].FixIdJA();
                     break;
-                    
+
                 case Boots boots:
                     if (this.OldBootsIds.ContainsKey(boots.ItemId))
                         boots.ItemId = this.OldBootsIds[boots.ItemId].FixIdJA();

--- a/SpaceCore/CustomCraftingRecipe.cs
+++ b/SpaceCore/CustomCraftingRecipe.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using SpaceShared;
 using StardewValley;
 using StardewValley.Objects;
 
@@ -16,7 +17,7 @@ namespace SpaceCore
 
         public abstract class IngredientMatcher
         {
-            public abstract string DispayName { get; }
+            public abstract string DisplayName { get; }
 
             public abstract Texture2D IconTexture { get; }
             public abstract Rectangle? IconSubrect { get; }
@@ -51,7 +52,7 @@ namespace SpaceCore
                 this.qty = quantity;
             }
 
-            public override string DispayName
+            public override string DisplayName
             {
                 get
                 {
@@ -70,9 +71,9 @@ namespace SpaceCore
                         };
                     }
                     string retString = Game1.content.LoadString("Strings\\StringsFromCSFiles:CraftingRecipe.cs.575");
-                    if (Game1.objectInformation.ContainsKey(this.objectIndex))
+                    if (Game1.objectData.ContainsKey(this.objectIndex))
                     {
-                        retString = Game1.objectInformation[this.objectIndex].Split('/')[4];
+                        retString = Game1.objectData[this.objectIndex].DisplayName;
                     }
                     return retString;
                 }

--- a/SpaceCore/Framework/CustomCraftingRecipe.cs
+++ b/SpaceCore/Framework/CustomCraftingRecipe.cs
@@ -66,7 +66,7 @@ namespace SpaceCore.Framework
                         required_count -= containers_count;
                     }
                 }
-                string ingredient_name_text = ingred.DispayName;
+                string ingredient_name_text = ingred.DisplayName;
                 Color drawColor = ((required_count <= 0) ? Game1.textColor : Color.Red);
                 b.Draw(ingred.IconTexture, new Vector2(position.X, position.Y + 64f + (float)(i * 64 / 2) + (float)(i * 4)), ingred.IconSubrect, Color.White, 0f, Vector2.Zero, 2f, SpriteEffects.None, 0.86f);
                 Utility.drawTinyDigits(ingred.Quantity, b, new Vector2(position.X + 32f - Game1.tinyFont.MeasureString(ingred.Quantity.ToString() ?? "").X, position.Y + 64f + (float)(i * 64 / 2) + (float)(i * 4) + 21f), 2f, 0.87f, Color.AntiqueWhite);


### PR DESCRIPTION
In the newest update, JsonAssets always throws an error when trying to fix the ids for the scythe weapon, because the `weapn.appearance.Value` is null. This "fixes" this.
It does it by checking if the appearance is null and if it is it breaks early out of the switch.
Is this the correct handling? Should it break out before manipulating the ItemId of the weapon? Should the check be more generic and happen at the start of the switch for every type of item? Or is this a completely different issue that should be fixed elsewhere?