### PR TITLE
[Magic] Update FixMagicIfNeeded

### DIFF
--- a/Magic/Framework/Magic.cs
+++ b/Magic/Framework/Magic.cs
@@ -114,6 +114,21 @@ namespace Magic.Framework
                 }
             }
 
+            // fix skill points
+            {
+                int expectedSkillPoints = magicLevel;
+                int totalSpent = 0;
+                foreach (PreparedSpell spell in spellBook.KnownSpells){
+                    if(spell.level > 1){
+                        totalSpent += spell.level - 1;
+                    }
+                }
+                if(expectedSkillPoints > spellBook.FreePoints + totalSpent){
+                        spellBook.UseSpellPoints(-(expectedSkillPoints - spellBook.FreePoints - totalSpent));
+                }
+            }
+
+
             // fix spell bars
             if (spellBook.Prepared.Count < MagicConstants.SpellBarCount)
             {


### PR DESCRIPTION
Function in pull request is missing a fix for skill points - connected to another bigger bug that I have no idea how to fix. 

In Multiplayer, players can be set to the level of the owner of the world due to unknown circumstances after unlocking magic. When this happens, though, the player whose level was set does not get the skill points and becomes unable to get those skill points that were skipped. Due to this, my assumption was that this was the function that was called, which is why I've added this change to at least give the players the correct amount of skill points.

**Just as a heads up, this is untested (unsure of how to test) but it should be pretty easy to fix up if it is wrong - am a little uncertain on whether my foreach is accessing the dictionary correctly.**