### PR TITLE
Add food buffs for custom skills

### DIFF
--- a/SpaceCore/Interface/NewSkillsPage.cs
+++ b/SpaceCore/Interface/NewSkillsPage.cs
@@ -311,7 +311,7 @@ namespace SpaceCore.Interface
                     int professionLevel = professionIndex - 1 + (professionIndex * 4);
                     Skills.Skill skill = Skills.GetSkill(skills[skillIndex]);
                     Skills.Skill.Profession profession = Skills.GetProfessionFor(skill, professionLevel + 1);// Game1.player.getProfessionForSkill(0, num4 + 1);
-                    bool drawRed = Game1.player.GetCustomSkillLevel(skill) > professionLevel;
+                    bool drawRed = Game1.player.GetCustomBuffedSkillLevel(skill) > professionLevel;
                     List<string> professionLines = new List<string>();
                     string professionBlurb = "";
                     string professionTitle = "";
@@ -450,8 +450,8 @@ namespace SpaceCore.Interface
                 Skills.Skill skill = Skills.GetSkill(skills[skillIndex]);
                 int actualSkillIndex = gameSkillCount + skillIndex;
                 string hoverText = "";
-                if (Game1.player.GetCustomSkillLevel(skill) > 0)
-                    hoverText = skill.GetSkillPageHoverText(Game1.player.GetCustomSkillLevel(skill));
+                if (Game1.player.GetCustomBuffedSkillLevel(skill) > 0)
+                    hoverText = skill.GetSkillPageHoverText(Game1.player.GetCustomBuffedSkillLevel(skill));
                 ClickableTextureComponent textureComponent = new ClickableTextureComponent(
                     name: NewSkillsPage.CustomSkillPrefix + skill.GetName(),
                     bounds: new Rectangle(addedX - 128 - 48, drawY + (actualSkillIndex * 56), 148, 36),
@@ -991,10 +991,10 @@ namespace SpaceCore.Interface
                     bool addedSkill = false;
                     string skillTitle = "";
 
-                    drawRed = Game1.player.GetCustomSkillLevel(skill) > levelIndex;
+                    drawRed = Game1.player.GetCustomBuffedSkillLevel(skill) > levelIndex;
                     if (levelIndex == 0)
                         skillTitle = skill.GetName();
-                    skillLevel = Game1.player.GetCustomSkillLevel(skill);
+                    skillLevel = Game1.player.GetCustomBuffedSkillLevel(skill);
                     // TODO: Detect skill buffs? Is that even possible?
                     addedSkill = false; // (int)((NetFieldBase<int, NetInt>)Game1.player.addedFarmingLevel) > 0;
                     if (skillTitle.Length > 0)

--- a/SpaceCore/Patches/SkillBuffPatcher.cs
+++ b/SpaceCore/Patches/SkillBuffPatcher.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Text;
+using HarmonyLib;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Spacechase.Shared.Patching;
+using SpaceShared;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.GameData.Objects;
+using StardewValley.Menus;
+
+namespace SpaceCore.Patches;
+internal class SkillBuffPatcher : BasePatcher
+{
+    public override void Apply(Harmony harmony, IMonitor monitor)
+    {
+        harmony.Patch(
+            original: this.RequireMethod<StardewValley.Object>(nameof(StardewValley.Object.GetFoodOrDrinkBuffs)),
+            postfix: this.GetHarmonyMethod(nameof(After_Object_GetFoodOrDrinkBuffs))
+        );
+        harmony.Patch(
+            original: this.RequireMethod<BuffsDisplay>(nameof(BuffsDisplay.getClickableComponents)),
+            postfix: this.GetHarmonyMethod(nameof(After_BuffsDisplay_GetClickableComponents))
+        );
+        harmony.Patch(
+            original: this.RequireMethod<IClickableMenu>(nameof(IClickableMenu.drawHoverText), new Type[] { typeof(SpriteBatch), typeof(StringBuilder), typeof(SpriteFont), typeof(int), typeof(int), typeof(int), typeof(string), typeof(int), typeof(string[]), typeof(Item), typeof(int), typeof(string), typeof(int), typeof(int), typeof(int), typeof(float), typeof(CraftingRecipe), typeof(List<Item>), typeof(Texture2D), typeof(Rectangle?), typeof(Color?), typeof(Color?) }),
+            transpiler: this.GetHarmonyMethod(nameof(Transpile_IClickableMenu_DrawHoverText))
+        );
+    }
+
+
+    private static IEnumerable<Buff> After_Object_GetFoodOrDrinkBuffs(IEnumerable<Buff> values, StardewValley.Object __instance)
+    {
+        // If there is no custom data, return normal buffs.
+        if (!Game1.objectData.TryGetValue(__instance.ItemId, out ObjectData data) ||
+            data.Buff is null ||
+            data.Buff.CustomFields is null ||
+            data.Buff.CustomFields.Count == 0)
+        {
+            foreach (Buff buff in values)
+            {
+                yield return buff;
+            }
+            yield break;
+        }
+
+        // If there is custom data, find the matching buff to wrap.
+        Buff matchingBuff = null;
+        string id = data.Buff.BuffId;
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            id = data.IsDrink ? "drink" : "food";
+        }
+        foreach (Buff buff in values)
+        {
+            if (buff.id != id)
+            {
+                yield return buff;
+            }
+            else
+            {
+                matchingBuff = buff;
+            }
+        }
+
+        // If there is no matching buff, we need to create one.
+        // Just using a different ID is enough to trick TryCreateBuffFromData into creating a non-null buff.
+        if (matchingBuff is null)
+        {
+            float durationMultiplier = ((__instance.Quality != 0) ? 1.5f : 1f);
+            string buffId = data.Buff.BuffId;
+            data.Buff.BuffId = "fake";
+            matchingBuff = StardewValley.Object.TryCreateBuffFromData(data, __instance.Name, __instance.DisplayName, durationMultiplier, __instance.ModifyItemBuffs);
+            data.Buff.BuffId = buffId;
+        }
+
+        // Replace matching buff with new CustomBuff, which copies customFields to player.modData
+        yield return new Skills.SkillBuff(matchingBuff, id, data.Buff.CustomFields);
+    }
+
+    private static IEnumerable<ClickableTextureComponent> After_BuffsDisplay_GetClickableComponents(IEnumerable<ClickableTextureComponent> values, Buff buff)
+    {
+        foreach (ClickableTextureComponent value in values)
+        {
+            yield return value;
+        }
+
+        if (buff.iconTexture is not null)
+        {
+            yield break;
+        }
+
+        if (buff is not Skills.SkillBuff customBuff)
+        {
+            yield break;
+        }
+
+        foreach (var skillLevel in customBuff.SkillLevelIncreases)
+        {
+            Skills.Skill skill = Skills.GetSkill(skillLevel.Key);
+            if (skill is null)
+            {
+                Log.Error($"Found no skill by name {skillLevel.Key}");
+                continue;
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append("+");
+            sb.Append(skillLevel.Value);
+            sb.Append(" ");
+            sb.Append(skill.GetName());
+            sb.Append("\n");
+            sb.Append(Game1.content.LoadString("Strings\\StringsFromCSFiles:Buff.cs.508"));
+            sb.Append(buff.displaySource ?? buff.source);
+
+            yield return new ClickableTextureComponent("", Rectangle.Empty, null, sb.ToString(), skill.Icon, new Rectangle(0, 0, 16, 16), 4f);
+        }
+    }
+
+    private static IEnumerable<CodeInstruction> Transpile_IClickableMenu_DrawHoverText(IEnumerable<CodeInstruction> instructions)
+    {
+        List<CodeInstruction> codeInstructions = new List<CodeInstruction>(instructions);
+        int step = 0;
+        yield return codeInstructions[0];
+        for (int i = 1; i < codeInstructions.Count; i++)
+        {
+            if (!codeInstructions[i - 1].Is(OpCodes.Ldarg_S, 8) || (!(codeInstructions[i].opcode == OpCodes.Brfalse_S) && !(codeInstructions[i].opcode == OpCodes.Brfalse)))
+            {
+                yield return codeInstructions[i];
+                continue;
+            }
+
+            if (step == 0)
+            {
+                yield return new CodeInstruction(OpCodes.Ldarg_S, 8);
+                yield return new CodeInstruction(OpCodes.Ldarg_S, 9);
+                yield return new CodeInstruction(OpCodes.Ldloc_2);
+                yield return CodeInstruction.Call(typeof(SkillBuffPatcher), nameof(GetHeightAdjustment));
+                yield return new CodeInstruction(OpCodes.Stloc_2);
+            }
+            else if (step == 1)
+            {
+                yield return new CodeInstruction(OpCodes.Ldarg_S, 2);
+                yield return new CodeInstruction(OpCodes.Ldarg_S, 9);
+                yield return new CodeInstruction(OpCodes.Ldloc_1);
+                yield return CodeInstruction.Call(typeof(SkillBuffPatcher), nameof(GetWidthAdjustment));
+                yield return new CodeInstruction(OpCodes.Stloc_1);
+            }
+            else if (step == 2)
+            {
+                yield return new CodeInstruction(OpCodes.Ldarg_S, 0);
+                yield return new CodeInstruction(OpCodes.Ldarg_S, 2);
+                yield return new CodeInstruction(OpCodes.Ldarg_S, 9);
+                yield return new CodeInstruction(OpCodes.Ldloc, 5);
+                yield return new CodeInstruction(OpCodes.Ldloc, 6);
+                yield return CodeInstruction.Call(typeof(SkillBuffPatcher), nameof(DrawCustomSkillBuff));
+                yield return new CodeInstruction(OpCodes.Stloc, 6);
+            }
+
+            yield return codeInstructions[i];
+            step++;
+        }
+    }
+
+    private static int GetHeightAdjustment(string[] buffIconsToDisplay, Item hoveredItem, int height)
+    {
+        if (hoveredItem is null ||
+            !Game1.objectData.TryGetValue(hoveredItem.ItemId, out ObjectData data) ||
+            data.Buff is null ||
+            data.Buff.CustomFields is null ||
+            data.Buff.CustomFields.Count == 0)
+        {
+            return height;
+        }
+
+        bool addedAny = false;
+        foreach (var entry in Skills.SkillBuff.ParseCustomFields(data.Buff.CustomFields))
+        {
+            addedAny = true;
+            height += 34;
+        }
+
+        if (buffIconsToDisplay is null && addedAny)
+        {
+            height += 4;
+        }
+
+        return height;
+    }
+
+    private static int GetWidthAdjustment(SpriteFont font, Item hoveredItem, int width)
+    {
+        if (hoveredItem is null ||
+            !Game1.objectData.TryGetValue(hoveredItem.ItemId, out ObjectData data) ||
+            data.Buff is null ||
+            data.Buff.CustomFields is null ||
+            data.Buff.CustomFields.Count == 0)
+        {
+            return width;
+        }
+
+        foreach (var entry in Skills.SkillBuff.ParseCustomFields(data.Buff.CustomFields))
+        {
+            Skills.Skill skill = Skills.GetSkill(entry.Key);
+
+            if (skill is null)
+            {
+                continue;
+            }
+
+            width = Math.Max(width, (int)font.MeasureString("+99 " + skill.GetName()).X) + 92;
+        }
+
+        return width;
+    }
+
+    private static int DrawCustomSkillBuff(SpriteBatch b, SpriteFont font, Item hoveredItem, int x, int y)
+    {
+        if (hoveredItem is null ||
+            !Game1.objectData.TryGetValue(hoveredItem.ItemId, out ObjectData data) ||
+            data.Buff is null ||
+            data.Buff.CustomFields is null ||
+            data.Buff.CustomFields.Count == 0)
+        {
+            return y;
+        }
+
+        foreach (var entry in Skills.SkillBuff.ParseCustomFields(data.Buff.CustomFields))
+        {
+            Skills.Skill skill = Skills.GetSkill(entry.Key);
+
+            if (skill is null)
+            {
+                continue;
+            }
+            string text = $"+{entry.Value}  {skill.GetName()}";
+
+            Utility.drawWithShadow(b, skill.SkillsPageIcon, new Vector2(x + 16 + 4, y + 16), new Rectangle(0, 0, 10, 10), Color.White, 0f, Vector2.Zero, 3f, flipped: false, 0.95f);
+            Utility.drawTextWithShadow(b, text, font, new Vector2(x + 16 + 34 + 4, y + 16), Game1.textColor);
+            y += 34;
+        }
+
+        return y;
+    }
+}

--- a/SpaceCore/Skills.cs
+++ b/SpaceCore/Skills.cs
@@ -105,13 +105,91 @@ namespace SpaceCore
             }
         }
 
+        public class SkillBuff : Buff
+        {
+            public Dictionary<string, int> SkillLevelIncreases { get; set; } = new Dictionary<string, int>();
+
+            private const string SkillBuffField = "spacechase.SpaceCore.SkillBuff.";
+
+            public SkillBuff(Buff buff, string id, Dictionary<string, string> customFields) : base(id, buff.source, buff.displaySource, buff.millisecondsDuration, buff.iconTexture, buff.iconSheetIndex, buff.effects, false, buff.displayName, buff.description)
+            {
+                foreach (var entry in ParseCustomFields(customFields))
+                {
+                    SkillLevelIncreases[entry.Key] = entry.Value;
+                }
+            }
+
+            public static IEnumerable<KeyValuePair<string, int>> ParseCustomFields(Dictionary<string, string> customFields)
+            {
+                foreach (KeyValuePair<string, string> entry in customFields)
+                {
+                    if (!entry.Key.StartsWith(SkillBuffField))
+                    {
+                        continue;
+                    }
+
+                    string skillId = entry.Key.Substring(SkillBuffField.Length);
+                    if (!int.TryParse(entry.Value, out int level))
+                    {
+                        Log.Error($"Could not parse int {entry.Value} from buff custom field {entry.Key}");
+                        continue;
+                    }
+
+                    yield return KeyValuePair.Create(skillId, level);
+                }
+            }
+
+            public override void OnAdded()
+            {
+                base.OnAdded();
+
+                using var stream = new MemoryStream();
+                using var writer = new BinaryWriter(stream);
+                writer.Write(this.id);
+                writer.Write(this.SkillLevelIncreases.Count);
+                foreach (var skill in this.SkillLevelIncreases)
+                {
+                    ValidateSkill(Game1.player, skill.Key);
+                    writer.Write(skill.Key);
+                    writer.Write(skill.Value);
+                    Skills.Buffs[Game1.player.UniqueMultiplayerID][skill.Key][this.id] = skill.Value;
+                    Log.Info($"Adding buff for skill {skill.Key} from source {this.id} at level {skill.Value}");
+                }
+
+                Networking.BroadcastMessage(Skills.MsgExperience, stream.ToArray());
+            }
+
+            public override void OnRemoved()
+            {
+                base.OnRemoved();
+
+                using var stream = new MemoryStream();
+                using var writer = new BinaryWriter(stream);
+                writer.Write(this.id);
+                writer.Write(this.SkillLevelIncreases.Count);
+                foreach (var skill in this.SkillLevelIncreases)
+                {
+                    ValidateSkill(Game1.player, skill.Key);
+                    writer.Write(skill.Key);
+                    writer.Write(0);
+                    Skills.Buffs[Game1.player.UniqueMultiplayerID][skill.Key].Remove(this.id);
+                    Log.Info($"Removing buff for skill {skill.Key} from source {this.id} at level {skill.Value}");
+                }
+
+                Networking.BroadcastMessage(Skills.MsgExperience, stream.ToArray());
+            }
+        }
+
         private static readonly string DataKey = "skills";
         private static string LegacyFilePath => Path.Combine(Constants.CurrentSavePath, "spacecore-skills.json");
         private const string MsgData = "spacechase0.SpaceCore.SkillData";
         private const string MsgExperience = "spacechase0.SpaceCore.SkillExperience";
+        private const string MsgBuffs = "spacechase0.SpaceCore.SkillBuffs";
 
         internal static Dictionary<string, Skill> SkillsByName = new(StringComparer.OrdinalIgnoreCase);
         private static Dictionary<long, Dictionary<string, int>> Exp = new();
+        // MultiplayerID => SkillID => BuffID => Level
+        private static Dictionary<long, Dictionary<string, Dictionary<string, int>>> Buffs = new();
         internal static List<KeyValuePair<string, int>> NewLevels = new();
 
         private static IExperienceBarsApi? BarsApi;
@@ -126,6 +204,7 @@ namespace SpaceCore
             SpaceEvents.ServerGotClient += Skills.ClientJoined;
             Networking.RegisterMessageHandler(Skills.MsgData, Skills.OnDataMessage);
             Networking.RegisterMessageHandler(Skills.MsgExperience, Skills.OnExpMessage);
+            Networking.RegisterMessageHandler(Skills.MsgBuffs, Skills.OnBuffsMessage);
 
             if (SpaceCore.Instance.Helper.ModRegistry.IsLoaded("cantorsdust.AllProfessions"))
                 events.Player.Warped += Skills.OnWarped;
@@ -188,6 +267,31 @@ namespace SpaceCore
             return 0;
         }
 
+        public static int GetSkillBuffLevel(Farmer farmer, string skillName, string? buffName = null)
+        {
+            if (!Skills.SkillsByName.ContainsKey(skillName))
+            {
+                return 0;
+            }
+            Skills.ValidateSkill(farmer, skillName);
+
+            if (buffName is not null)
+            {
+                if (!Skills.Buffs[farmer.UniqueMultiplayerID][skillName].TryGetValue(buffName, out int level))
+                {
+                    level = 0;
+                }
+                return level;
+            }
+
+            int totalLevel = 0;
+            foreach (var buff in Skills.Buffs[farmer.UniqueMultiplayerID][skillName])
+            {
+                totalLevel += buff.Value;
+            }
+            return totalLevel;
+        }
+
         public static void AddExperience(Farmer farmer, string skillName, int amt)
         {
             if (!Skills.SkillsByName.ContainsKey(skillName))
@@ -209,26 +313,31 @@ namespace SpaceCore
 
         private static void ValidateSkill(Farmer farmer, string skillName)
         {
-            if (!Skills.Exp.TryGetValue(farmer.UniqueMultiplayerID, out var skillExp))
+            ValidateSkill(farmer.UniqueMultiplayerID, skillName);
+        }
+
+        private static void ValidateSkill(long uniqueMultiplayerId, string skillName)
+        {
+            if (!Skills.Exp.TryGetValue(uniqueMultiplayerId, out var skillExp))
             {
                 skillExp = new();
-                Skills.Exp.Add(farmer.UniqueMultiplayerID, skillExp);
+                Skills.Exp.Add(uniqueMultiplayerId, skillExp);
+            }
+            if (!Skills.Buffs.TryGetValue(uniqueMultiplayerId, out var skillBuffs))
+            {
+                skillBuffs = new();
+                Skills.Buffs.Add(uniqueMultiplayerId, skillBuffs);
             }
 
             _ = skillExp.TryAdd(skillName, 0);
+            _ = skillBuffs.TryAdd(skillName, new());
         }
 
         private static void ClientJoined(object sender, EventArgsServerGotClient args)
         {
-            if (!Skills.Exp.TryGetValue(args.FarmerID, out var skillExp))
-            {
-                skillExp = new();
-                Skills.Exp.Add(args.FarmerID, skillExp);
-            }
-
             foreach (var skill in Skills.SkillsByName)
             {
-                _ = skillExp.TryAdd(skill.Key, 0);
+                ValidateSkill(args.FarmerID, skill.Key);
             }
 
             using var stream = new MemoryStream();
@@ -245,8 +354,45 @@ namespace SpaceCore
                 }
             }
 
+            writer.Write(Skills.Buffs.Count);
+            foreach (var data in Skills.Buffs)
+            {
+                writer.Write(data.Key);
+                writer.Write(data.Value.Count);
+                foreach (var skill in data.Value)
+                {
+                    writer.Write(skill.Key);
+                    writer.Write(skill.Value.Count);
+                    foreach (var buff in skill.Value)
+                    {
+                        writer.Write(buff.Key);
+                        writer.Write(buff.Value);
+                    }
+                }
+            }
+
             Log.Trace("Sending skill data to " + args.FarmerID);
             Networking.ServerSendTo(args.FarmerID, Skills.MsgData, stream.ToArray());
+        }
+
+        private static void OnBuffsMessage(IncomingMessage msg)
+        {
+            string buffId = msg.Reader.ReadString();
+            int count = msg.Reader.ReadInt32();
+            for (int i = 0; i < count; ++i)
+            {
+                string skill = msg.Reader.ReadString();
+                int level = msg.Reader.ReadInt32();
+
+                if (level == 0)
+                {
+                    Skills.Buffs[msg.FarmerID][skill].Remove(buffId);
+                }
+                else
+                {
+                    Skills.Buffs[msg.FarmerID][skill][buffId] = level;
+                }
+            }
         }
 
         private static void OnExpMessage(IncomingMessage msg)
@@ -275,6 +421,41 @@ namespace SpaceCore
                     }
                     skillExp[skill] = amt;
                     Log.Trace($"\t{skill}={amt}");
+                }
+            }
+
+            Log.Trace("Got buff data!");
+            int playerCount = msg.Reader.ReadInt32();
+            for (int playerIndex = 0; playerIndex < playerCount; ++playerIndex)
+            {
+                long playerId = msg.Reader.ReadInt64();
+                Log.Trace($"\t{playerId}:");
+                int skillCount = msg.Reader.ReadInt32();
+                for (int skillIndex = 0; skillIndex < skillCount; ++skillIndex)
+                {
+                    if (!Skills.Buffs.TryGetValue(playerId, out var playerSkills))
+                    {
+                        playerSkills = new();
+                        Skills.Buffs.Add(playerId, playerSkills);
+                    }
+
+                    string skillId = msg.Reader.ReadString();
+                    Log.Trace($"\t\t{skillId}:");
+                    int buffCount = msg.Reader.ReadInt32();
+
+                    for (int buffIndex = 0; buffIndex < buffCount; ++buffIndex)
+                    {
+                        if (!playerSkills.TryGetValue(skillId, out var playerSkillBuffs))
+                        {
+                            playerSkillBuffs = new();
+                            playerSkills.Add(skillId, playerSkillBuffs);
+                        }
+
+                        string buffId = msg.Reader.ReadString();
+                        int level = msg.Reader.ReadInt32();
+                        playerSkillBuffs[buffId] = level;
+                        Log.Trace($"\t\t{buffId}={level}");
+                    }
                 }
             }
         }
@@ -498,6 +679,26 @@ namespace SpaceCore
         public static int GetCustomSkillLevel(this Farmer farmer, string skill)
         {
             return Skills.GetSkillLevel(farmer, skill);
+        }
+
+        public static int GetCustomBuffedSkillLevel(this Farmer farmer, Skills.Skill skill)
+        {
+            return Skills.GetSkillLevel(farmer, skill.Id) + Skills.GetSkillBuffLevel(farmer, skill.Id);
+        }
+
+        public static int GetCustomBuffedSkillLevel(this Farmer farmer, string skill)
+        {
+            return Skills.GetSkillLevel(farmer, skill) + Skills.GetSkillBuffLevel(farmer, skill);
+        }
+
+        public static int GetCustomSkillBuffAmount(this Farmer farmer, Skills.Skill skill, string buffId = null)
+        {
+            return Skills.GetSkillBuffLevel(farmer, skill.Id, buffId);
+        }
+
+        public static int GetCustomSkillBuffAmount(this Farmer farmer, string skill, string buffId = null)
+        {
+            return Skills.GetSkillBuffLevel(farmer, skill, buffId);
         }
 
         public static void AddCustomSkillExperience(this Farmer farmer, Skills.Skill skill, int amt)

--- a/SpaceCore/SpaceCore.cs
+++ b/SpaceCore/SpaceCore.cs
@@ -289,7 +289,8 @@ namespace SpaceCore
                 new SaveGamePatcher(serializerManager),
                 new SerializationPatcher(),
                 new UtilityPatcher(),
-                new HoeDirtPatcher()
+                new HoeDirtPatcher(),
+                new SkillBuffPatcher()
             );
             /*
             var ps = typeof(NetDictionary<string, string, NetString, SerializableDictionary<string, string>, NetStringDictionary<string, NetString>>).GetProperties();


### PR DESCRIPTION
Adds tracking of buffs for custom skills.

Using this requires adding a custom field to a item buff in 1.6, like so:

```
{
    "Format": "1.29.0",
    "Changes": [
        {
            "Action": "EditData",
            "Target": "Data/Objects",
            "Entries": {
                "drbirbdev.BinningSkill_FishCasserol": {
                    "Name": "Fish Casserol",
                    "DisplayName": "{{i18n:item.FishCasserol.name}}",
                    "Description": "{{i18n:item.FishCasserol.desc}}",
                    "Type": "Cooking",
                    "Category": -7,
                    "Price": 150,
                    "Texture": "Mods/drbirbdev.BinningSkill/BigCraftables",
                    "SpriteIndex": 5,
                    "Edibility": 50,
                    "IsDrink": false,
                    "Buff": {
                        "Duration": 500,
                        "CustomFields": {
                            "spacechase.SpaceCore.SkillBuff.drbirbdev.Binning": "3",
                            "spacechase.SpaceCore.SkillBuff.drbirbdev.Socializing": "2"
                        }
                    }
                }
            }
        }
    ]
}
```

This probably needs an API to get skill level including buffs.

Getting skill level without buff is the default behavior, so other mods would need to be updated for this to apply.