### PR TITLE
Fix recipes

### DIFF
--- a/JsonAssets/Data/ObjectRecipe.cs
+++ b/JsonAssets/Data/ObjectRecipe.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using JsonAssets.Framework;
@@ -31,7 +32,25 @@ namespace JsonAssets.Data
         {
             string str = "";
             foreach (var ingredient in this.Ingredients)
-                str += ingredient.Object.ToString().FixIdJA() + " " + ingredient.Count + " ";
+            {
+                string ingredientName = ingredient.Object.ToString().FixIdJA();
+                // If the original object name is an integer, it's a category or an original ID
+                if (int.TryParse(ingredient.Object.ToString(), out int ingredIndex))
+                {
+                    ingredientName = ingredIndex.ToString();
+                }
+                // If the object isn't an integer, check if it's the name of an existing item
+                else if (ItemRegistry.GetDataOrErrorItem(ingredientName).IsErrorItem)
+                {
+                    Item tryGetItem = Utility.fuzzyItemSearch(ingredientName);
+                    if (tryGetItem != null)
+                    {
+                        ingredientName = tryGetItem.ItemId;
+                    }
+                }
+                // Otherwise leave name untouched
+                str += ingredientName + " " + ingredient.Count + " ";
+            }
             str = str.Substring(0, str.Length - 1);
             if (parent.Category != ObjectCategory.Cooking)
                 str += "/what is this for?";

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -587,7 +587,7 @@ namespace JsonAssets
                     PurchaseFrom = hat.PurchaseFrom,
                     Price = hat.PurchasePrice,
                     PurchaseRequirements = ParsedConditions.AlwaysTrue,
-                    Object = () => new Hat(hat.Name)
+                    Object = () => new Hat(hat.Name.FixIdJA())
                 });
             }
 


### PR DESCRIPTION
Recipes previously broke if either a) they used the vanilla item's name as the ingredient name or b) used a category as the ingredient. This PR fixes both those cases. 