### PR TITLE
[ThreeHeartDancePartner] Fix bug with rejection text comparison

### DIFF
--- a/ThreeHeartDancePartner/Mod.cs
+++ b/ThreeHeartDancePartner/Mod.cs
@@ -86,7 +86,8 @@ namespace ThreeHeartDancePartner
             NPC npc = dialog.speaker;
             if (!npc.datable.Value || npc.HasPartnerForDance)
                 return;
-            string rejectionText = Game1.content.Load<Dictionary<string, string>>($"Characters\\Dialogue\\{dialog.speaker.Name}")["FlowerDance_Decline"];
+
+            string rejectionText = new Dialogue(dialog.speaker, null, Game1.content.Load<Dictionary<string, string>>($"Characters\\Dialogue\\{dialog.speaker.Name}")["FlowerDance_Decline"]).getCurrentDialogue();
             if (dialog.getCurrentDialogue() != rejectionText)
                 return;
 


### PR DESCRIPTION
Some characters' rejection text (Leah, Elliot, maybe others) when loaded from Game1.content.Load<Dictionary<string, string>>($"Characters\\Dialogue\\{dialog.speaker.Name}")["FlowerDance_Decline"] would end in "$s", while dialog.getCurrentDialogue() would not. This caused the mod to think that the player wasn't being rejected when they were. This update puts that text in a Dialogue object and then uses that Dialogue's getCurrentDialogue() function to avoid this problem. This is how it worked before my 1.6 update, and I didn't notice that my change caused this bug in my testing because I only tested characters that didn't have this issue.