### PR TITLE
Fix trailing spaces texture error and duplicate items very bad error

### DIFF
--- a/JsonAssets/Data/BigCraftableData.cs
+++ b/JsonAssets/Data/BigCraftableData.cs
@@ -60,7 +60,7 @@ namespace JsonAssets.Data
                 Price = this.Price,
                 Fragility = 0,
                 IsLamp = ProvidesLight,
-                Texture = $"JA\\BigCraftable0\\{Name}",
+                Texture = $"JA\\BigCraftable0\\{Name.FixIdJA()}",
                 SpriteIndex = 0,
             };
         }

--- a/JsonAssets/Data/BootsData.cs
+++ b/JsonAssets/Data/BootsData.cs
@@ -55,7 +55,7 @@ namespace JsonAssets.Data
 
         internal string GetBootsInformation()
         {
-            return $"{this.Name}/{this.LocalizedDescription()}/{this.Price}/{this.Defense}/{this.Immunity}/0/{this.LocalizedName()}/JA\\BootsColor\\{Name}/0/JA\\Boots\\{Name}";
+            return $"{this.Name}/{this.LocalizedDescription()}/{this.Price}/{this.Defense}/{this.Immunity}/0/{this.LocalizedName()}/JA\\BootsColor\\{Name.FixIdJA()}/0/JA\\Boots\\{Name.FixIdJA()}";
         }
 
 

--- a/JsonAssets/Data/ClothingData.cs
+++ b/JsonAssets/Data/ClothingData.cs
@@ -60,7 +60,7 @@ namespace JsonAssets.Data
 
         internal string GetClothingInformation()
         {
-            return $"{this.Name}/{this.LocalizedName()}/{this.LocalizedDescription()}/{this.GetMaleIndex()}/{this.GetFemaleIndex()}/{this.Price}/{this.DefaultColor.R} {this.DefaultColor.G} {this.DefaultColor.B}/{this.Dyeable}/Shirt/{this.Metadata}/JA\\ShirtMale\\{this.Name}";
+            return $"{this.Name}/{this.LocalizedName()}/{this.LocalizedDescription()}/{this.GetMaleIndex()}/{this.GetFemaleIndex()}/{this.Price}/{this.DefaultColor.R} {this.DefaultColor.G} {this.DefaultColor.B}/{this.Dyeable}/Shirt/{this.Metadata}/JA\\ShirtMale\\{this.Name.FixIdJA()}";
         }
 
 

--- a/JsonAssets/Data/HatData.cs
+++ b/JsonAssets/Data/HatData.cs
@@ -39,7 +39,7 @@ namespace JsonAssets.Data
         *********/
         internal string GetHatInformation()
         {
-            return $"{this.Name}/{this.LocalizedDescription()}/" + (this.ShowHair ? "true" : "false") + "/" + (this.IgnoreHairstyleOffset ? "true" : "false") + $"/{this.Metadata}/{this.LocalizedName()}/0/JA\\Hat\\{Name}";
+            return $"{this.Name}/{this.LocalizedDescription()}/" + (this.ShowHair ? "true" : "false") + "/" + (this.IgnoreHairstyleOffset ? "true" : "false") + $"/{this.Metadata}/{this.LocalizedName()}/0/JA\\Hat\\{Name.FixIdJA()}";
         }
 
 

--- a/JsonAssets/Data/ObjectData.cs
+++ b/JsonAssets/Data/ObjectData.cs
@@ -78,7 +78,7 @@ namespace JsonAssets.Data
                 Type = Category == ObjectCategory.Artifact ? "Arch" : (Category == ObjectCategory.Ring ? "Ring" : "Basic"),
                 Category = (int)this.Category,
                 Price = Price,
-                Texture = $"JA\\Object\\{Name}",
+                Texture = $"JA\\Object\\{Name.FixIdJA()}",
                 SpriteIndex = 0,
                 Edibility = Edibility,
                 IsDrink = EdibleIsDrink,

--- a/JsonAssets/Data/PantsData.cs
+++ b/JsonAssets/Data/PantsData.cs
@@ -49,7 +49,7 @@ namespace JsonAssets.Data
 
         internal string GetClothingInformation()
         {
-            return $"{this.Name}/{this.LocalizedName()}/{this.LocalizedDescription()}/0/-1/{this.Price}/{this.DefaultColor.R} {this.DefaultColor.G} {this.DefaultColor.B}/{this.Dyeable}/Pants/{this.Metadata}/JA\\Pants\\{this.Name}";
+            return $"{this.Name}/{this.LocalizedName()}/{this.LocalizedDescription()}/0/-1/{this.Price}/{this.DefaultColor.R} {this.DefaultColor.G} {this.DefaultColor.B}/{this.Dyeable}/Pants/{this.Metadata}/JA\\Pants\\{this.Name.FixIdJA()}";
         }
 
 

--- a/JsonAssets/Data/WeaponData.cs
+++ b/JsonAssets/Data/WeaponData.cs
@@ -52,7 +52,7 @@ namespace JsonAssets.Data
         *********/
         internal string GetWeaponInformation()
         {
-            return $"{this.Name}/{this.LocalizedDescription()}/{this.MinimumDamage}/{this.MaximumDamage}/{this.Knockback}/{this.Speed}/{this.Accuracy}/{this.Defense}/{(int)this.Type}/{this.MineDropVar}/{this.MineDropMinimumLevel}/{this.ExtraSwingArea}/{this.CritChance}/{this.CritMultiplier}/{this.LocalizedName()}/0/JA\\Weapon\\{this.Name}";
+            return $"{this.Name}/{this.LocalizedDescription()}/{this.MinimumDamage}/{this.MaximumDamage}/{this.Knockback}/{this.Speed}/{this.Accuracy}/{this.Defense}/{(int)this.Type}/{this.MineDropVar}/{this.MineDropMinimumLevel}/{this.ExtraSwingArea}/{this.CritChance}/{this.CritMultiplier}/{this.LocalizedName()}/0/JA\\Weapon\\{this.Name.FixIdJA()}";
         }
 
 

--- a/JsonAssets/Framework/ContentInjector1.cs
+++ b/JsonAssets/Framework/ContentInjector1.cs
@@ -10,6 +10,9 @@ using SpaceShared;
 using StardewModdingAPI;
 using StardewValley;
 using StardewValley.GameData.Crafting;
+using StardewValley.Monsters;
+using StardewValley.Objects;
+using StardewValley.TerrainFeatures;
 
 namespace JsonAssets.Framework
 {
@@ -40,44 +43,115 @@ namespace JsonAssets.Framework
             this.ToLoad = new();
             foreach (var obj in Mod.instance.Objects)
             {
-                ToLoad.Add("JA/Object/" + obj.Name, obj.Texture);
-                if (obj.TextureColor != null)
-                    ToLoad.Add("JA/ObjectColor/" + obj.Name, obj.TextureColor);
+                try
+                {
+                    ToLoad.Add("JA/Object/" + obj.Name.FixIdJA(), obj.Texture);
+                    if (obj.TextureColor != null)
+                        ToLoad.Add("JA/ObjectColor/" + obj.Name.FixIdJA(), obj.TextureColor);
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"Exception loading object texture for {obj.Name.FixIdJA()}: {e}");
+                }
             }
             foreach (var crop in Mod.instance.Crops)
             {
-                ToLoad.Add("JA/Crop/" + crop.Name, crop.Texture);
-                if (crop.GiantTexture != null)
-                    ToLoad.Add("JA/CropGiant/" + crop.Name, crop.GiantTexture);
+                try
+                {
+                    ToLoad.Add("JA/Crop/" + crop.Name, crop.Texture);
+                    if (crop.GiantTexture != null)
+                        ToLoad.Add("JA/CropGiant/" + crop.Name, crop.GiantTexture);
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"Exception loading crop texture for {crop.Name}: {e}");
+                }
             }
             foreach (var ftree in Mod.instance.FruitTrees)
-                ToLoad.Add("JA/FruitTree/" + ftree.Name, ftree.Texture);
+            {
+                try
+                {
+                    ToLoad.Add("JA/FruitTree/" + ftree.Name, ftree.Texture);
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"Exception loading fruit tree texture for {ftree.Name}: {e}");
+                }
+            }
             foreach (var big in Mod.instance.BigCraftables)
             {
-                ToLoad.Add("JA/BigCraftable0/" + big.Name, big.Texture);
-                for (int i = 0; i < big.ExtraTextures.Length; ++i)
-                    ToLoad.Add("JA/BigCraftable" + (i + 1) + "/" + big.Name, big.ExtraTextures[i]);
+                try
+                {
+                    ToLoad.Add("JA/BigCraftable0/" + big.Name.FixIdJA(), big.Texture);
+                    for (int i = 0; i < big.ExtraTextures.Length; ++i)
+                        ToLoad.Add("JA/BigCraftable" + (i + 1) + "/" + big.Name.FixIdJA(), big.ExtraTextures[i]);
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"Exception loading big craftable texture for {big.Name.FixIdJA()}: {e}");
+                }
             }
             foreach (var hat in Mod.instance.Hats)
-                ToLoad.Add("JA/Hat/" + hat.Name, hat.Texture);
+            {
+                try
+                {
+                    ToLoad.Add("JA/Hat/" + hat.Name.FixIdJA(), hat.Texture);
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"Exception loading hat texture for {hat.Name.FixIdJA()}: {e}");
+                }
+            }
             foreach (var weapon in Mod.instance.Weapons)
-                ToLoad.Add("JA/Weapon/" + weapon.Name, weapon.Texture);
+            {
+                try
+                {
+                    ToLoad.Add("JA/Weapon/" + weapon.Name.FixIdJA(), weapon.Texture);
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"Exception loading weapon texture for {weapon.Name.FixIdJA()}: {e}");
+                }
+            }
             foreach ( var shirt in Mod.instance.Shirts )
             {
-                ToLoad.Add("JA/ShirtMale/" + shirt.Name, shirt.TextureMale);
-                if (shirt.TextureFemale != null)
-                    ToLoad.Add("JA/ShirtFemale/" + shirt.Name, shirt.TextureFemale);
-                if (shirt.TextureMaleColor != null)
-                    ToLoad.Add("JA/ShirtMaleColor/" + shirt.Name, shirt.TextureMaleColor);
-                if (shirt.TextureFemaleColor != null)
-                    ToLoad.Add("JA/ShirtFemaleColor/" + shirt.Name, shirt.TextureFemaleColor);
+                try
+                {
+                    ToLoad.Add("JA/ShirtMale/" + shirt.Name.FixIdJA(), shirt.TextureMale);
+                    if (shirt.TextureFemale != null)
+                        ToLoad.Add("JA/ShirtFemale/" + shirt.Name.FixIdJA(), shirt.TextureFemale);
+                    if (shirt.TextureMaleColor != null)
+                        ToLoad.Add("JA/ShirtMaleColor/" + shirt.Name.FixIdJA(), shirt.TextureMaleColor);
+                    if (shirt.TextureFemaleColor != null)
+                        ToLoad.Add("JA/ShirtFemaleColor/" + shirt.Name.FixIdJA(), shirt.TextureFemaleColor);
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"Exception loading shirt texture for {shirt.Name.FixIdJA()}: {e}");
+                }
             }
             foreach ( var pants in Mod.instance.Pants )
-                ToLoad.Add("JA/Pants/" + pants.Name, pants.Texture);
+            {
+                try
+                {
+                    ToLoad.Add("JA/Pants/" + pants.Name.FixIdJA(), pants.Texture);
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"Exception loading pants texture for {pants.Name.FixIdJA()}: {e}");
+                }
+            }
             foreach ( var boots in Mod.instance.Boots )
             {
-                ToLoad.Add("JA/Boots/" + boots.Name, boots.Texture);
-                ToLoad.Add("JA/BootsColor/" + boots.Name, boots.TextureColor);
+                try
+                {
+                    ToLoad.Add("JA/Boots/" + boots.Name.FixIdJA(), boots.Texture);
+                    ToLoad.Add("JA/BootsColor/" + boots.Name.FixIdJA(), boots.TextureColor);
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"Exception loading boots texture for {boots.Name.FixIdJA()}: {e}");
+                }
             }
             // TODO custom fence when they implement them in vanilla
 

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -41,7 +41,7 @@ namespace JsonAssets
         private static Regex NameFixer = new("[^a-zA-Z0-9_]", RegexOptions.Compiled);
         public static string FixIdJA(this string before)
         {
-            return NameFixer.Replace(before, "_");
+            return NameFixer.Replace(before.Trim(), "_");
         }
     }
 

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -1751,9 +1751,6 @@ namespace JsonAssets
                             if (this.FixId(this.OldObjectIds, this.ObjectIds, obj.preservedParentSheetIndex, this.VanillaObjectIds))
                                 obj.preservedParentSheetIndex.Value = -1;
                             */
-                            this.OldObjectIds.TryGetValue(obj.ItemId, out string newID);
-                            string corrID = newID == null ? "none" : newID.FixIdJA();
-                            Monitor.Log($"Object found with ID {obj.ItemId}, new ID {newID}, correct to {corrID}", LogLevel.Info);
                             if (this.OldObjectIds.ContainsKey(obj.ItemId))
                                 obj.ItemId = this.OldObjectIds[obj.ItemId].FixIdJA();
                         }

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -1460,7 +1460,7 @@ namespace JsonAssets
                 var objs = LoadDictionary<string, int>("ids-objects.json");
                 foreach (string key in objs.Keys)
                 {
-                    if (!DupObjects.ContainsKey(key))
+                    if (!DupObjects.ContainsKey(key.FixIdJA()))
                         OldObjectIds.Remove(objs[key].ToString());
                 }
                 var crops = LoadDictionary<string, int>("ids-crops.json");
@@ -1478,31 +1478,31 @@ namespace JsonAssets
                 var bigs = LoadDictionary<string, int>("ids-big-craftables.json");
                 foreach (string key in bigs.Keys)
                 {
-                    if (!DupBigCraftables.ContainsKey(key))
+                    if (!DupBigCraftables.ContainsKey(key.FixIdJA()))
                         OldBigCraftableIds.Remove(bigs[key].ToString());
                 }
                 var hats = LoadDictionary<string, int>("ids-hats.json");
                 foreach (string key in hats.Keys)
                 {
-                    if (!DupHats.ContainsKey(key))
+                    if (!DupHats.ContainsKey(key.FixIdJA()))
                         OldHatIds.Remove(hats[key].ToString());
                 }
                 var weapons = LoadDictionary<string, int>("ids-weapons.json");
                 foreach (string key in weapons.Keys)
                 {
-                    if (!DupWeapons.ContainsKey(key))
+                    if (!DupWeapons.ContainsKey(key.FixIdJA()))
                         OldWeaponIds.Remove(weapons[key].ToString());
                 }
                 var clothing = LoadDictionary<string, int>("ids-clothing.json");
                 foreach (string key in clothing.Keys)
                 {
-                    if (!DupShirts.ContainsKey(key) && !DupPants.ContainsKey(key))
+                    if (!DupShirts.ContainsKey(key.FixIdJA()) && !DupPants.ContainsKey(key.FixIdJA()))
                         OldClothingIds.Remove(clothing[key].ToString());
                 }
                 var boots = LoadDictionary<string, int>("ids-boots.json");
                 foreach (string key in boots.Keys)
                 {
-                    if (!DupBoots.ContainsKey(key))
+                    if (!DupBoots.ContainsKey(key.FixIdJA()))
                         OldBootsIds.Remove(boots[key].ToString());
                 }
             }
@@ -1751,6 +1751,9 @@ namespace JsonAssets
                             if (this.FixId(this.OldObjectIds, this.ObjectIds, obj.preservedParentSheetIndex, this.VanillaObjectIds))
                                 obj.preservedParentSheetIndex.Value = -1;
                             */
+                            this.OldObjectIds.TryGetValue(obj.ItemId, out string newID);
+                            string corrID = newID == null ? "none" : newID.FixIdJA();
+                            Monitor.Log($"Object found with ID {obj.ItemId}, new ID {newID}, correct to {corrID}", LogLevel.Info);
                             if (this.OldObjectIds.ContainsKey(obj.ItemId))
                                 obj.ItemId = this.OldObjectIds[obj.ItemId].FixIdJA();
                         }


### PR DESCRIPTION
This fixes a couple things:
- The game hates it when an item name ends in a space, and throws a texture error every time the item is referenced. To fix this, I added .Trim() to the FixJAId function and made all the textures get stored until the fixed IDs, not the pre-fixed IDs.
- However, removing trailing spaces causes even more duplicate items than before, which basically crashes the mod (no items load, do not pass go), so I added in error handling so that the mod spews red text but doesn't crash when there's duplicate objects (you can also remove the red text part). The only downside to this approach is that this does mean the catch part of the try-catch block gets hit more often than is optimal. But I couldn't easily figure out anything better. It's possible the DupDicts might help.