### PR TITLE
Fix crops, shipped items, recipes known

### DIFF
--- a/JsonAssets/Data/CropData.cs
+++ b/JsonAssets/Data/CropData.cs
@@ -83,7 +83,7 @@ namespace JsonAssets.Data
             }
             else
                 str += "false";
-            str += $"/JA\\Crop\\{this.Name}";
+            str += $"/JA\\Crop\\{this.Name.FixIdJA()}";
             return str;
         }
 

--- a/JsonAssets/Data/FruitTreeData.cs
+++ b/JsonAssets/Data/FruitTreeData.cs
@@ -37,7 +37,7 @@ namespace JsonAssets.Data
 
         internal string GetFruitTreeInformation()
         {
-            return $"0/{this.Season}/{this.Product}/what goes here?/0/JA\\FruitTree\\{this.Name}";
+            return $"0/{this.Season}/{this.Product}/what goes here?/0/JA\\FruitTree\\{this.Name.FixIdJA()}";
         }
 
 

--- a/JsonAssets/Framework/ContentInjector1.cs
+++ b/JsonAssets/Framework/ContentInjector1.cs
@@ -58,9 +58,9 @@ namespace JsonAssets.Framework
             {
                 try
                 {
-                    ToLoad.Add("JA/Crop/" + crop.Name, crop.Texture);
+                    ToLoad.Add("JA/Crop/" + crop.Name.FixIdJA(), crop.Texture);
                     if (crop.GiantTexture != null)
-                        ToLoad.Add("JA/CropGiant/" + crop.Name, crop.GiantTexture);
+                        ToLoad.Add("JA/CropGiant/" + crop.Name.FixIdJA(), crop.GiantTexture);
                 }
                 catch (Exception e)
                 {
@@ -71,11 +71,11 @@ namespace JsonAssets.Framework
             {
                 try
                 {
-                    ToLoad.Add("JA/FruitTree/" + ftree.Name, ftree.Texture);
+                    ToLoad.Add("JA/FruitTree/" + ftree.Name.FixIdJA(), ftree.Texture);
                 }
                 catch (Exception e)
                 {
-                    Log.Error($"Exception loading fruit tree texture for {ftree.Name}: {e}");
+                    Log.Error($"Exception loading fruit tree texture for {ftree.Name.FixIdJA()}: {e}");
                 }
             }
             foreach (var big in Mod.instance.BigCraftables)
@@ -244,12 +244,12 @@ namespace JsonAssets.Framework
                         ExtraHarvestChance = crop.Bonus?.ExtraChance ?? 0,
                         HarvestMethod = crop.HarvestWithScythe ? StardewValley.GameData.Crops.HarvestMethod.Scythe : StardewValley.GameData.Crops.HarvestMethod.Grab,
                         TintColors = colors,
-                        Texture = "JA/Crop/" + crop.Name,
+                        Texture = "JA/Crop/" + crop.Name.FixIdJA(),
                     });
                 }
                 catch (Exception e)
                 {
-                    Log.Error($"Exception injecting crop for {crop.Name}: {e}");
+                    Log.Error($"Exception injecting crop for {crop.Name.FixIdJA()}: {e}");
                 }
             }
         }
@@ -272,14 +272,14 @@ namespace JsonAssets.Framework
                                 ItemId = "(O)" + fruitTree.Product.ToString(),
                             }
                         } ),
-                        Texture = "JA/FruitTree/" + fruitTree.Name,
+                        Texture = "JA/FruitTree/" + fruitTree.Name.FixIdJA(),
                         TextureSpriteRow = 0,
 
                     });
                 }
                 catch (Exception e)
                 {
-                    Log.Error($"Exception injecting fruit tree for {fruitTree.Name}: {e}");
+                    Log.Error($"Exception injecting fruit tree for {fruitTree.Name.FixIdJA()}: {e}");
                 }
             }
         }
@@ -294,12 +294,12 @@ namespace JsonAssets.Framework
                         continue;
                     if (obj.Category != ObjectCategory.Cooking)
                         continue;
-                    Log.Verbose($"Injecting to cooking recipes: {obj.Name}: {obj.Recipe.GetRecipeString(obj)}");
-                    data.Add(obj.Name, obj.Recipe.GetRecipeString(obj));
+                    Log.Verbose($"Injecting to cooking recipes: {obj.Name.FixIdJA()}: {obj.Recipe.GetRecipeString(obj)}");
+                    data.Add(obj.Name.FixIdJA(), obj.Recipe.GetRecipeString(obj));
                 }
                 catch (Exception e)
                 {
-                    Log.Error($"Exception injecting cooking recipe for {obj.Name}: {e}");
+                    Log.Error($"Exception injecting cooking recipe for {obj.Name.FixIdJA()}: {e}");
                 }
             }
         }
@@ -314,12 +314,12 @@ namespace JsonAssets.Framework
                         continue;
                     if (obj.Category == ObjectCategory.Cooking)
                         continue;
-                    Log.Verbose($"Injecting to crafting recipes: {obj.Name}: {obj.Recipe.GetRecipeString(obj)}");
+                    Log.Verbose($"Injecting to crafting recipes: {obj.Name.FixIdJA()}: {obj.Recipe.GetRecipeString(obj)}");
                     data.Add(obj.Name.FixIdJA(), obj.Recipe.GetRecipeString(obj));
                 }
                 catch (Exception e)
                 {
-                    Log.Error($"Exception injecting crafting recipe for {obj.Name}: {e}");
+                    Log.Error($"Exception injecting crafting recipe for {obj.Name.FixIdJA()}: {e}");
                 }
             }
             foreach (var big in Mod.instance.BigCraftables)
@@ -328,12 +328,12 @@ namespace JsonAssets.Framework
                 {
                     if (big.Recipe == null)
                         continue;
-                    Log.Verbose($"Injecting to crafting recipes: {big.Name}: {big.Recipe.GetRecipeString(big)}");
+                    Log.Verbose($"Injecting to crafting recipes: {big.Name.FixIdJA()}: {big.Recipe.GetRecipeString(big)}");
                     data.Add(big.Name.FixIdJA(), big.Recipe.GetRecipeString(big));
                 }
                 catch (Exception e)
                 {
-                    Log.Error($"Exception injecting crafting recipe for {big.Name}: {e}");
+                    Log.Error($"Exception injecting crafting recipe for {big.Name.FixIdJA()}: {e}");
                 }
             }
         }
@@ -344,12 +344,12 @@ namespace JsonAssets.Framework
             {
                 try
                 {
-                    Log.Verbose($"Injecting to big craftables: {big.Name}: {big.GetCraftableInformation()}");
+                    Log.Verbose($"Injecting to big craftables: {big.Name.FixIdJA()}: {big.GetCraftableInformation()}");
                     data.Add(big.Name.FixIdJA(), big.GetCraftableInformation());
                 }
                 catch (Exception e)
                 {
-                    Log.Error($"Exception injecting object information for {big.Name}: {e}");
+                    Log.Error($"Exception injecting object information for {big.Name.FixIdJA()}: {e}");
                 }
             }
         }
@@ -360,12 +360,12 @@ namespace JsonAssets.Framework
             {
                 try
                 {
-                    Log.Verbose($"Injecting to hats: {hat.Name}: {hat.GetHatInformation()}");
+                    Log.Verbose($"Injecting to hats: {hat.Name.FixIdJA()}: {hat.GetHatInformation()}");
                     data.Add(hat.Name.FixIdJA(), hat.GetHatInformation());
                 }
                 catch (Exception e)
                 {
-                    Log.Error($"Exception injecting hat information for {hat.Name}: {e}");
+                    Log.Error($"Exception injecting hat information for {hat.Name.FixIdJA()}: {e}");
                 }
             }
         }
@@ -394,13 +394,13 @@ namespace JsonAssets.Framework
                         AreaOfEffect = weapon.ExtraSwingArea,
                         CritChance = ( float ) weapon.CritChance,
                         CritMultiplier = ( float ) weapon.CritMultiplier,
-                        Texture = $"JA/Weapon/{weapon.Name}",
+                        Texture = $"JA/Weapon/{weapon.Name.FixIdJA()}",
                         SpriteIndex = 0,
                     }); ;
                 }
                 catch (Exception e)
                 {
-                    Log.Error($"Exception injecting weapon information for {weapon.Name}: {e}");
+                    Log.Error($"Exception injecting weapon information for {weapon.Name.FixIdJA()}: {e}");
                 }
             }
         }
@@ -411,24 +411,24 @@ namespace JsonAssets.Framework
             {
                 try
                 {
-                    Log.Verbose($"Injecting to clothing information: {shirt.Name}: {shirt.GetClothingInformation()}");
+                    Log.Verbose($"Injecting to clothing information: {shirt.Name.FixIdJA()}: {shirt.GetClothingInformation()}");
                     data.Add(shirt.Name.FixIdJA(), shirt.GetClothingInformation());
                 }
                 catch (Exception e)
                 {
-                    Log.Error($"Exception injecting clothing information for {shirt.Name}: {e}");
+                    Log.Error($"Exception injecting clothing information for {shirt.Name.FixIdJA()}: {e}");
                 }
             }
             foreach (var pants in Mod.instance.Pants)
             {
                 try
                 {
-                    Log.Verbose($"Injecting to clothing information: {pants.Name}: {pants.GetClothingInformation()}");
+                    Log.Verbose($"Injecting to clothing information: {pants.Name.FixIdJA()}: {pants.GetClothingInformation()}");
                     data.Add(pants.Name.FixIdJA(), pants.GetClothingInformation());
                 }
                 catch (Exception e)
                 {
-                    Log.Error($"Exception injecting clothing information for {pants.Name}: {e}");
+                    Log.Error($"Exception injecting clothing information for {pants.Name.FixIdJA()}: {e}");
                 }
             }
         }
@@ -455,12 +455,12 @@ namespace JsonAssets.Framework
             {
                 try
                 {
-                    Log.Verbose($"Injecting to boots: {boots.Name}: {boots.GetBootsInformation()}");
+                    Log.Verbose($"Injecting to boots: {boots.Name.FixIdJA()}: {boots.GetBootsInformation()}");
                     data.Add(boots.Name.FixIdJA(), boots.GetBootsInformation());
                 }
                 catch (Exception e)
                 {
-                    Log.Error($"Exception injecting boots information for {boots.Name}: {e}");
+                    Log.Error($"Exception injecting boots information for {boots.Name.FixIdJA()}: {e}");
                 }
             }
         }

--- a/JsonAssets/Framework/ContentInjector1.cs
+++ b/JsonAssets/Framework/ContentInjector1.cs
@@ -269,7 +269,7 @@ namespace JsonAssets.Framework
                         {
                             new StardewValley.GameData.FruitTrees.FruitTreeFruitData()
                             {
-                                ItemId = "(O)" + fruitTree.Product.ToString(),
+                                ItemId = "(O)" + fruitTree.Product.ToString().FixIdJA(),
                             }
                         } ),
                         Texture = "JA/FruitTree/" + fruitTree.Name.FixIdJA(),

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -308,7 +308,7 @@ namespace JsonAssets
             // validate
             if (!this.AssertHasName(crop, "crop", source, translations))
                 return;
-            if (!this.AssertHasName(crop.Seed, "crop seed", source, translations, discriminator: $"crop: {crop.Name}", fieldName: nameof(crop.SeedName)))
+            if (!this.AssertHasName(crop.Seed, "crop seed", source, translations, discriminator: $"crop: {crop.Name.FixIdJA()}", fieldName: nameof(crop.SeedName)))
                 return;
 
             // save crop data
@@ -370,13 +370,13 @@ namespace JsonAssets
             }
 
             // check for duplicates
-            if (this.DupCrops.TryGetValue(crop.Name, out IManifest prevManifest))
+            if (this.DupCrops.TryGetValue(crop.Name.FixIdJA(), out IManifest prevManifest))
             {
-                Log.Error($"Duplicate crop: {crop.Name} just added by {source.Name}, already added by {prevManifest.Name}!");
+                Log.Error($"Duplicate crop: {crop.Name.FixIdJA()} just added by {source.Name}, already added by {prevManifest.Name}!");
                 return;
             }
             else
-                this.DupCrops[crop.Name] = source;
+                this.DupCrops[crop.Name.FixIdJA()] = source;
 
             // check for duplicates
             if (this.DupObjects.TryGetValue(crop.Seed.Name.FixIdJA(), out IManifest prevManifest2))
@@ -438,7 +438,7 @@ namespace JsonAssets
             // validate
             if (!this.AssertHasName(tree, "fruit tree", source, translations))
                 return;
-            if (!this.AssertHasName(tree.Sapling, "fruit tree sapling", source, translations, discriminator: $"fruit tree: {tree.Name}", fieldName: nameof(tree.SaplingName)))
+            if (!this.AssertHasName(tree.Sapling, "fruit tree sapling", source, translations, discriminator: $"fruit tree: {tree.Name.FixIdJA()}", fieldName: nameof(tree.SaplingName)))
                 return;
 
             // save data
@@ -468,13 +468,13 @@ namespace JsonAssets
             }
 
             // check for duplicates
-            if (this.DupFruitTrees.TryGetValue(tree.Name, out IManifest prevManifest))
+            if (this.DupFruitTrees.TryGetValue(tree.Name.FixIdJA(), out IManifest prevManifest))
             {
-                Log.Error($"Duplicate fruit tree: {tree.Name} just added by {source.Name}, already added by {prevManifest.Name}!");
+                Log.Error($"Duplicate fruit tree: {tree.Name.FixIdJA()} just added by {source.Name}, already added by {prevManifest.Name}!");
                 return;
             }
             else
-                this.DupFruitTrees[tree.Name] = source;
+                this.DupFruitTrees[tree.Name.FixIdJA()] = source;
 
             // check for duplicates
             if (this.DupObjects.TryGetValue(tree.Sapling.Name.FixIdJA(), out IManifest prevManifest2))
@@ -1485,13 +1485,13 @@ namespace JsonAssets
                 var crops = LoadDictionary<string, int>("ids-crops.json");
                 foreach (string key in crops.Keys)
                 {
-                    if (!DupCrops.ContainsKey(key))
+                    if (!DupCrops.ContainsKey(key.FixIdJA()))
                         OldCropIds.Remove(crops[key].ToString());
                 }
                 var ftrees = LoadDictionary<string, int>("ids-fruittrees.json");
                 foreach (string key in ftrees.Keys)
                 {
-                    if (!DupFruitTrees.ContainsKey(key))
+                    if (!DupFruitTrees.ContainsKey(key.FixIdJA()))
                         OldFruitTreeIds.Remove(ftrees[key].ToString());
                 }
                 var bigs = LoadDictionary<string, int>("ids-big-craftables.json");
@@ -1897,9 +1897,16 @@ namespace JsonAssets
 
                 case FruitTree ftree:
                     {
-                        if (this.OldFruitTreeIds.ContainsKey(ftree.treeId.Value))
+                        try
                         {
-                            ftree.treeId.Value = this.OldFruitTreeIds[ftree.treeId.Value].FixIdJA();
+                            if (this.OldFruitTreeIds.ContainsKey(ftree.treeId.Value))
+                            {
+                                ftree.treeId.Value = this.OldFruitTreeIds[ftree.treeId.Value].FixIdJA();
+                            }
+                        }
+                        catch
+                        {
+
                         }
                     }
                     break;

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -1951,7 +1951,7 @@ namespace JsonAssets
                 if (this.OldObjectIds.ContainsKey(entry))
                 {
                     toRemove.Add(entry);
-                    toAdd.Add(this.OldObjectIds[entry].FixIdJA(), dict[entry]);
+                    toAdd.TryAdd(this.OldObjectIds[entry].FixIdJA(), dict[entry]);
                 }
             }
             foreach (string entry in toRemove)

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -1980,7 +1980,7 @@ namespace JsonAssets
                 if (this.OldObjectIds.ContainsKey(entry))
                 {
                     toRemove.Add(entry);
-                    toAdd.Add(this.OldObjectIds[entry].FixIdJA(), dict[entry]);
+                    toAdd.TryAdd(this.OldObjectIds[entry].FixIdJA(), dict[entry]);
                 }
             }
             foreach (string entry in toRemove)


### PR DESCRIPTION
- Migrate crops and fruit trees in line with previous PRs to use fixed JA ID for the textures
- Fix misc other logging statements that should use the fixed JA IDs
- Properly null-check on fruit tree migration
- Migrate crops in saves even if they have a space in their name
- Migrate the known recipes (crafting and cooking) via a new method, because they started out with string IDs, they just need the spaces removed
- Fix shipped items and other dictionary migrations to no longer choke and die if two items have the same name
- Fix fruit tree migrations (yay!!)
- Fix fruit tree products not using the right names