### PR TITLE
[1.6 Spacecore] Shrunk skill scroll bar to be next to skills only.

### DIFF
--- a/SpaceCore/Interface/NewSkillsPage.cs
+++ b/SpaceCore/Interface/NewSkillsPage.cs
@@ -311,10 +311,14 @@ namespace SpaceCore.Interface
             }
 
             // scrollbar
+
+            /// 0.675 is as close as I can get to having the scroll bar end 2 pixels below the bottom most skill.
+            /// 2 pixels below was chosen since the scroll bar goes 2 pixels above the top most skill.
+            int shrunkHeight = (int)(height * 0.675);
             this.upButton = new ClickableTextureComponent(new Rectangle(this.xPositionOnScreen + width + 16, this.yPositionOnScreen + 64, 44, 48), Game1.mouseCursors, new Rectangle(421, 459, 11, 12), 4f);
-            this.downButton = new ClickableTextureComponent(new Rectangle(this.xPositionOnScreen + width + 16, this.yPositionOnScreen + height - 64, 44, 48), Game1.mouseCursors, new Rectangle(421, 472, 11, 12), 4f);
+            this.downButton = new ClickableTextureComponent(new Rectangle(this.xPositionOnScreen + width + 16, this.yPositionOnScreen + shrunkHeight - 64, 44, 48), Game1.mouseCursors, new Rectangle(421, 472, 11, 12), 4f);
             this.scrollBar = new ClickableTextureComponent(new Rectangle(this.upButton.bounds.X + 12, this.upButton.bounds.Y + this.upButton.bounds.Height + 4, 24, 40), Game1.mouseCursors, new Rectangle(435, 463, 6, 10), 4f);
-            this.scrollBarRunner = new Rectangle(this.scrollBar.bounds.X, this.upButton.bounds.Y + this.upButton.bounds.Height + 4, this.scrollBar.bounds.Width, height - 128 - this.upButton.bounds.Height - 8);
+            this.scrollBarRunner = new Rectangle(this.scrollBar.bounds.X, this.upButton.bounds.Y + this.upButton.bounds.Height + 4, this.scrollBar.bounds.Width, shrunkHeight - 128 - this.upButton.bounds.Height - 8);
 
             // Add/update navigation
             this.populateClickableComponentList();


### PR DESCRIPTION
![20240403113821_1](https://github.com/spacechase0/StardewValleyMods/assets/52937167/1d51d6e9-71e0-4450-be6d-1edf3454fda5)

Shrunk Scrollbar to line up with the skill section of the skill page. Since you are only going to be scrolling that area and not the whole page. 