### PR TITLE
Parse the season string as multiple seasons, comma-separated

### DIFF
--- a/JsonAssets/Data/FruitTreeData.cs
+++ b/JsonAssets/Data/FruitTreeData.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using JsonAssets.Framework;
+using StardewValley;
+using StardewValley.TerrainFeatures;
 
 namespace JsonAssets.Data
 {
@@ -35,9 +38,23 @@ namespace JsonAssets.Data
             return this.Sapling.Name;
         }
 
-        internal string GetFruitTreeInformation()
+        internal StardewValley.GameData.FruitTrees.FruitTreeData GetFruitTreeInformation()
         {
-            return $"0/{this.Season}/{this.Product}/what goes here?/0/JA\\FruitTree\\{this.Name.FixIdJA()}";
+            var ret = new StardewValley.GameData.FruitTrees.FruitTreeData()
+            {
+                DisplayName = this.Name,
+                Seasons = this.GetSeasons(),
+                Fruit = new(new[]
+                {
+                    new StardewValley.GameData.FruitTrees.FruitTreeFruitData()
+                    {
+                        ItemId = "(O)" + this.Product.ToString().FixIdJA(),
+                    }
+                }),
+                Texture = "JA/FruitTree/" + this.Name.FixIdJA(),
+                TextureSpriteRow = 0,
+            };
+            return ret;
         }
 
 
@@ -56,6 +73,17 @@ namespace JsonAssets.Data
 
             this.SaplingPurchaseRequirements.FilterNulls();
             this.SaplingAdditionalPurchaseData.FilterNulls();
+        }
+
+        private List<Season> GetSeasons()
+        {
+            string[] seasonNames = this.Season.Split(",");
+            List<Season> seasonList = new();
+            foreach (string s in seasonNames)
+            {
+                seasonList.Add(Enum.Parse<Season>(s.Trim().Substring(0, 1).ToUpper() + s.Trim().Substring(1)));
+            }
+            return seasonList;
         }
     }
 }

--- a/JsonAssets/Framework/ContentInjector1.cs
+++ b/JsonAssets/Framework/ContentInjector1.cs
@@ -261,21 +261,7 @@ namespace JsonAssets.Framework
                 try
                 {
                     Log.Verbose($"Injecting to fruit trees: {fruitTree.GetSaplingId()}: {fruitTree.GetFruitTreeInformation()}");
-                    data.Add(fruitTree.GetSaplingId().FixIdJA(), new()
-                    {
-                        DisplayName = fruitTree.Name,
-                        Seasons = new(new[] { Enum.Parse<Season>(fruitTree.Season.Substring(0, 1).ToUpper() + fruitTree.Season.Substring(1)) } ),
-                        Fruit = new( new[]
-                        {
-                            new StardewValley.GameData.FruitTrees.FruitTreeFruitData()
-                            {
-                                ItemId = "(O)" + fruitTree.Product.ToString().FixIdJA(),
-                            }
-                        } ),
-                        Texture = "JA/FruitTree/" + fruitTree.Name.FixIdJA(),
-                        TextureSpriteRow = 0,
-
-                    });
+                    data.Add(fruitTree.GetSaplingId().FixIdJA(), fruitTree.GetFruitTreeInformation());
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
For some reason one of my fruit tree packs had the season set to be "Spring, summer, fall", which didn't used to error and die in 1.5.6 (I have no idea why not). I rewrote the seasons data format to do a string split on commas and then parse the enum on each, so that old packs would still work (instead of making it a string list). This is pretty optional as far as bug fixes go, but it seemed nice. 

Also now fruit trees don't have an obsolete incorrect GetFruitTreeInformation method, but instead have the proper format migrated from the ContentInjector into FruitTreeData.