### PR TITLE
Fix fruit tree merge conflict + Add new migrators for within 1.6 + Fix tailoring recipes + Foolproof recipes + more token fix

### DIFF
--- a/JsonAssets/Data/BigCraftableRecipe.cs
+++ b/JsonAssets/Data/BigCraftableRecipe.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using JsonAssets.Framework;
+using SpaceShared;
 using StardewValley;
 
 namespace JsonAssets.Data
@@ -37,13 +38,19 @@ namespace JsonAssets.Data
                 if (int.TryParse(ingredientName, out int ingredIndex))
                 {
                     ingredientName = ingredIndex.ToString();
+                    // Check if it's valid item or category, if it's not then skip adding the item
+                    if (ItemRegistry.GetDataOrErrorItem(ingredientName).IsErrorItem && StardewValley.Object.GetCategoryDisplayName(ingredIndex) == "")
+                    {
+                        Log.Warn($"Invalid recipe ingredient:{ingredient.Object.ToString()}");
+                        continue;
+                    }
                 }
                 // If the object is a JA object, then just use that
                 else if (ingredient.Object.ToString().FixIdJA("O") != null)
                 {
                     ingredientName = ingredient.Object.ToString().FixIdJA("O");
                 }
-                // If the object isn't an integer or a JA object, check if it's the name of any existing item and use that
+                // If the object isn't an integer, or a JA object, or an existing item, check if it's close to the name of any existing item and use that if so
                 else if (ItemRegistry.GetDataOrErrorItem(ingredientName).IsErrorItem)
                 {
                     Item tryGetItem = Utility.fuzzyItemSearch(ingredientName);
@@ -51,9 +58,21 @@ namespace JsonAssets.Data
                     {
                         ingredientName = tryGetItem.ItemId;
                     }
+                    // Don't add the ingredient if it's not a valid item
+                    else
+                    {
+                        Log.Warn($"Invalid recipe ingredient:{ingredient.Object.ToString()}");
+                        continue;
+                    }
                 }
-                // Otherwise leave name untouched
+                // Finally, add the ingredient name if it now matches an existing item
                 str += ingredientName + " " + ingredient.Count + " ";
+            }
+            // If no ingredients were added, add the torch recipe ingredients
+            if (str == "")
+            {
+                Log.Warn($"Recipe with no valid ingredients:{parent.Name}");
+                str += "388 1 92 2 ";
             }
             str = str.Substring(0, str.Length - 1);
             str += $"/what is this for?/{parent.Name.FixIdJA("BC")} {this.ResultCount}/true/";

--- a/JsonAssets/Data/FruitTreeData.cs
+++ b/JsonAssets/Data/FruitTreeData.cs
@@ -45,7 +45,22 @@ namespace JsonAssets.Data
 
         internal StardewValley.GameData.FruitTrees.FruitTreeData GetFruitTreeInformation()
         {
-            return $"0/{this.Season}/{this.Product}/what goes here?/0/JA\\FruitTree\\{this.Name.FixIdJA("FruitTree")}";
+            StardewValley.GameData.FruitTrees.FruitTreeData ftree = new()
+            {
+                DisplayName = this.Name,
+                Seasons = this.GetSeasons(),
+                Fruit = new(new[]
+                        {
+                            new StardewValley.GameData.FruitTrees.FruitTreeFruitData()
+                            {
+                                ItemId = "(O)" + this.Product.ToString().FixIdJA("O"),
+                            }
+                        }),
+                Texture = "JA/FruitTree/" + this.Name.FixIdJA("FruitTree"),
+                TextureSpriteRow = 0,
+
+            };
+            return ftree;
         }
 
 

--- a/JsonAssets/Data/TailoringRecipeData.cs
+++ b/JsonAssets/Data/TailoringRecipeData.cs
@@ -38,7 +38,7 @@ namespace JsonAssets.Data
 
             recipe.CraftedItemIds = new List<string>();
             foreach (object entry in this.CraftedItems)
-                recipe.CraftedItemIds.Add(this.CraftedItems[0].ToString()); // TODO: always uses first crafted item?
+                recipe.CraftedItemIds.Add(GetCraftedItem(entry.ToString())); // TODO: always uses first crafted item?
 
             return recipe;
         }
@@ -59,6 +59,19 @@ namespace JsonAssets.Data
             this.FirstItemTags.FilterNulls();
             this.SecondItemTags.FilterNulls();
             this.CraftedItems.FilterNulls();
+        }
+
+        private string GetCraftedItem(string itemName)
+        {
+            if (itemName.FixIdJA("S") != null)
+                return itemName.FixIdJA("S");
+            else if (itemName.FixIdJA("P") != null)
+                return itemName.FixIdJA("P");
+            else if (itemName.FixIdJA("B") != null)
+                return itemName.FixIdJA("B");
+            else if (!StardewValley.ItemRegistry.GetDataOrErrorItem(itemName).IsErrorItem)
+                return StardewValley.ItemRegistry.GetDataOrErrorItem(itemName).ItemId;
+            else return itemName;
         }
     }
 }

--- a/JsonAssets/Framework/ContentInjector1.cs
+++ b/JsonAssets/Framework/ContentInjector1.cs
@@ -263,21 +263,7 @@ namespace JsonAssets.Framework
                 try
                 {
                     Log.Verbose($"Injecting to fruit trees: {fruitTree.GetSaplingId()}: {fruitTree.GetFruitTreeInformation()}");
-                    data.Add(fruitTree.GetSaplingId().FixIdJA("O"), new()
-                    {
-                        DisplayName = fruitTree.Name,
-                        Seasons = new(new[] { Enum.Parse<Season>(fruitTree.Season.Substring(0, 1).ToUpper() + fruitTree.Season.Substring(1)) } ),
-                        Fruit = new( new[]
-                        {
-                            new StardewValley.GameData.FruitTrees.FruitTreeFruitData()
-                            {
-                                ItemId = "(O)" + fruitTree.Product.ToString().FixIdJA("O"),
-                            }
-                        } ),
-                        Texture = "JA/FruitTree/" + fruitTree.Name.FixIdJA("FruitTree"),
-                        TextureSpriteRow = 0,
-
-                    });
+                    data.Add(fruitTree.GetSaplingId().FixIdJA("O"), fruitTree.GetFruitTreeInformation());
                 }
                 catch (Exception e)
                 {

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -1819,8 +1819,13 @@ namespace JsonAssets
             switch (item)
             {
                 case Hat hat:
+                    // Migrate from 1.5.6
                     if (hat.obsolete_which.HasValue && this.OldHatIds.ContainsKey(hat.obsolete_which.Value.ToString()))
                         hat.ItemId = this.OldHatIds[hat.obsolete_which.Value.ToString()].FixIdJA("H");
+                    // Migrate from previous 1.6
+                    if (Mod.DupHats.ContainsKey(hat.ItemId) && hat.ItemId.FixIdJA("H") != null)
+                        hat.ItemId = hat.ItemId.FixIdJA("H");
+                    // Half-migrate removed hat mods
                     if (int.TryParse(hat.ItemId, out int hatNum) && this.RemovedHats.ContainsKey(hatNum))
                     {
                         Log.Trace($"Attempting to migrate removed hat! ID {hat.ItemId} and name {this.RemovedHats[hatNum]}");
@@ -1835,10 +1840,19 @@ namespace JsonAssets
                     break;
 
                 case MeleeWeapon weapon:
+                    // Migrate from 1.5.6
                     if (this.OldWeaponIds.ContainsKey(weapon.ItemId))
                         weapon.ItemId = this.OldWeaponIds[weapon.ItemId].FixIdJA("W");
+                    // Migrate appearance from 1.5.6
                     if (weapon.appearance.Value != null && this.OldWeaponIds.ContainsKey(weapon.appearance.Value))
                         weapon.appearance.Value = this.OldWeaponIds[weapon.appearance.Value].FixIdJA("W");
+                    // Migrate from previous 1.6
+                    if (Mod.DupWeapons.ContainsKey(weapon.ItemId) && weapon.ItemId.FixIdJA("W") != null)
+                        weapon.ItemId = weapon.ItemId.FixIdJA("W");
+                    // Migrate appearance from previous 1.6
+                    if (weapon.appearance.Value != null && Mod.DupWeapons.ContainsKey(weapon.appearance.Value) && weapon.appearance.Value.FixIdJA("W") != null)
+                        weapon.appearance.Value = weapon.appearance.Value.FixIdJA("W");
+                    // Half-migrate removed JA weapons
                     if (int.TryParse(weapon.ItemId, out int weaponNum) && this.RemovedWeapons.ContainsKey(weaponNum))
                     {
                         Log.Trace($"Attempting to migrate removed weapon! ID {weapon.ItemId} and name {this.RemovedWeapons[weaponNum]}");
@@ -1853,9 +1867,13 @@ namespace JsonAssets
                     break;
 
                 case Ring ring:
+                    // Migrate from 1.5.6
                     if (this.OldObjectIds.ContainsKey(ring.ItemId))
                         ring.ItemId = this.OldObjectIds[ring.ItemId].FixIdJA("O");
-
+                    // Migrate from previous 1.6
+                    if (Mod.DupObjects.ContainsKey(ring.ItemId) && ring.ItemId.FixIdJA("O") != null)
+                        ring.ItemId = ring.ItemId.FixIdJA("O");
+                    // Half-migrate removed JA rings
                     if (int.TryParse(ring.ItemId, out int ringNum) && this.RemovedObjects.ContainsKey(ringNum))
                     {
                         Log.Trace($"Attempting to migrate removed ring! ID {ring.ItemId} and name {this.RemovedObjects[ringNum]}");
@@ -1868,6 +1886,7 @@ namespace JsonAssets
                             ring.ItemId = name.FixIdJA();
                     }
 
+                    // Recursively fix combined rings
                     if (ring is CombinedRing combinedRing)
                     {
                         for (int i = combinedRing.combinedRings.Count - 1; i >= 0; i--)
@@ -1878,6 +1897,7 @@ namespace JsonAssets
                     break;
 
                 case Clothing clothing:
+                    // Migrate from 1.5.6
                     if (this.OldClothingIds.ContainsKey(clothing.ItemId))
                     {
                         if (this.OldClothingIds[clothing.ItemId].FixIdJA("P") != null)
@@ -1885,6 +1905,12 @@ namespace JsonAssets
                         if (this.OldClothingIds[clothing.ItemId].FixIdJA("S") != null)
                             clothing.ItemId = this.OldClothingIds[clothing.ItemId].FixIdJA("S");
                     }
+                    // Migrate from previous version in 1.6
+                    if (Mod.DupPants.ContainsKey(clothing.ItemId) && clothing.ItemId.FixIdJA("P") != null)
+                        clothing.ItemId = clothing.ItemId.FixIdJA("P");
+                    if (Mod.DupShirts.ContainsKey(clothing.ItemId) && clothing.ItemId.FixIdJA("S") != null)
+                        clothing.ItemId = clothing.ItemId.FixIdJA("S");
+                    // Half-migrate removed JA clothing
                     if (int.TryParse(clothing.ItemId, out int clothesNum) && this.RemovedClothing.ContainsKey(clothesNum))
                     {
                         Log.Trace($"Attempting to migrate removed clothing! ID {clothing.ItemId} and name {this.RemovedClothing[clothesNum]}");
@@ -1903,9 +1929,13 @@ namespace JsonAssets
                     break;
 
                 case Boots boots:
+                    // Migrate from 1.5.6
                     if (this.OldBootsIds.ContainsKey(boots.ItemId))
                         boots.ItemId = this.OldBootsIds[boots.ItemId].FixIdJA("B");
-
+                    // Migrate from previous 1.6
+                    if (Mod.DupBoots.ContainsKey(boots.ItemId) && boots.ItemId.FixIdJA("B") != null)
+                        boots.ItemId = boots.ItemId.FixIdJA("B");
+                    // Half-migrate removed JA boots
                     if (int.TryParse(boots.ItemId, out int bootsNum) && this.RemovedBoots.ContainsKey(bootsNum))
                     {
                         Log.Trace($"Attempting to migrate removed boots! ID {boots.ItemId} and name {this.RemovedObjects[bootsNum]}");
@@ -1922,14 +1952,21 @@ namespace JsonAssets
                     break;
 
                 case SObject obj:
+                    // Check chests for the items in them
                     if (obj is Chest chest)
                     {
+                        // Migrate chest from 1.5.6
                         if (this.OldBigCraftableIds.ContainsKey(chest.ItemId))
                             chest.ItemId = this.OldBigCraftableIds[chest.ItemId].FixIdJA("BC");
                         else
                             chest.startingLidFrame.Value = chest.ParentSheetIndex + 1;
+                        // Migrate chest from previous 1.6
+                        if (Mod.DupBigCraftables.ContainsKey(chest.ItemId) && chest.ItemId.FixIdJA("BC") != null)
+                            chest.ItemId = chest.ItemId.FixIdJA("BC");
+                        // Fix stuff in the chest
                         this.FixItemList(chest.Items);
                     }
+                    // Check garden pots for the crops in them
                     else if (obj is IndoorPot pot)
                     {
                         if (pot.hoeDirt.Value != null && pot.hoeDirt.Value.crop != null)
@@ -1947,9 +1984,13 @@ namespace JsonAssets
                             if (this.FixId(this.OldObjectIds, this.ObjectIds, obj.preservedParentSheetIndex, this.VanillaObjectIds))
                                 obj.preservedParentSheetIndex.Value = -1;
                             */
+                            // Migrate from 1.5.6
                             if (this.OldObjectIds.ContainsKey(obj.ItemId))
                                 obj.ItemId = this.OldObjectIds[obj.ItemId].FixIdJA("O");
-
+                            // Migrate objects from previous 1.6
+                            if (Mod.DupObjects.ContainsKey(obj.ItemId) && obj.ItemId.FixIdJA("O") != null)
+                                obj.ItemId = obj.ItemId.FixIdJA("O");
+                            // Half-migrate removed objects
                             if (int.TryParse(obj.ItemId, out int objNum) && this.RemovedObjects.ContainsKey(objNum))
                             {
                                 Log.Trace($"Attempting to migrate removed object! ID {obj.ItemId} and name {this.RemovedObjects[objNum]}");
@@ -1964,9 +2005,13 @@ namespace JsonAssets
                         }
                         else
                         {
+                            // Migrate from 1.5.6
                             if (this.OldBigCraftableIds.ContainsKey(obj.ItemId))
                                 obj.ItemId = this.OldBigCraftableIds[obj.ItemId].FixIdJA("BC");
-
+                            // Migrate big craftable from previous 1.6
+                            if (Mod.DupBigCraftables.ContainsKey(obj.ItemId) && obj.ItemId.FixIdJA("BC") != null)
+                                obj.ItemId = obj.ItemId.FixIdJA("BC");
+                            // Half-migrate removed JA big craftables
                             if (int.TryParse(obj.ItemId, out int objNum) && this.RemovedBigCraftables.ContainsKey(objNum))
                             {
                                 Log.Trace($"Attempting to migrate removed big craftable! ID {obj.ItemId} and name {this.RemovedBigCraftables[objNum]}");
@@ -1980,12 +2025,29 @@ namespace JsonAssets
                             }
                         }
                     }
-
+                    // Migrate held objects
                     if (obj.heldObject.Value != null)
                     {
+                        // Migrate from 1.5.6
                         if (this.OldObjectIds.ContainsKey(obj.heldObject.Value.ItemId))
                             obj.heldObject.Value.ItemId = this.OldObjectIds[obj.heldObject.Value.ItemId].FixIdJA("O");
+                        // Migrate objects from previous 1.6
+                        if (Mod.DupObjects.ContainsKey(obj.heldObject.Value.ItemId) && obj.heldObject.Value.ItemId.FixIdJA("O") != null)
+                            obj.heldObject.Value.ItemId = obj.heldObject.Value.ItemId.FixIdJA("O");
+                        // Half-migrate removed objects
+                        if (int.TryParse(obj.heldObject.Value.ItemId, out int objNum) && this.RemovedObjects.ContainsKey(objNum))
+                        {
+                            Log.Trace($"Attempting to migrate removed object! ID {obj.heldObject.Value.ItemId} and name {this.RemovedObjects[objNum]}");
+                            string name = this.RemovedObjects[objNum].ToString();
+                            if (ItemRegistry.GetData("(O)" + name) != null)
+                                obj.heldObject.Value.ItemId = ItemRegistry.GetData("(O)" + name).ItemId;
+                            else if (ItemRegistry.GetData("(O)" + name.FixIdJA()) != null)
+                                obj.heldObject.Value.ItemId = ItemRegistry.GetData("(O)" + name.FixIdJA()).ItemId;
+                            else
+                                obj.heldObject.Value.ItemId = name.FixIdJA();
+                        }
 
+                        // Migrate stuff inside inner chest
                         if (obj.heldObject.Value is Chest innerChest)
                             this.FixItemList(innerChest.Items);
                     }
@@ -2045,8 +2107,27 @@ namespace JsonAssets
                         break;
                     }
 
+                    // Migrate the fish from 1.5.6
                     if (pond.fishType.Value != null && this.OldObjectIds.ContainsKey(pond.fishType.Value))
                         pond.fishType.Value = this.OldObjectIds[pond.fishType.Value].FixIdJA("O");
+
+                    // Migrate fish from previous 1.6
+                    if (Mod.DupObjects.ContainsKey(pond.fishType.Value) && pond.fishType.Value.FixIdJA("O") != null)
+                        pond.fishType.Value = pond.fishType.Value.FixIdJA("O");
+
+                    // Half-migrate removed JA fish
+                    if (int.TryParse(pond.fishType.Value, out int objNum) && this.RemovedObjects.ContainsKey(objNum))
+                    {
+                        Log.Trace($"Attempting to migrate removed object! ID {pond.fishType.Value} and name {this.RemovedObjects[objNum]}");
+                        string name = this.RemovedObjects[objNum].ToString();
+                        if (ItemRegistry.GetData("(O)" + name) != null)
+                            pond.fishType.Value = ItemRegistry.GetData("(O)" + name).ItemId;
+                        else if (ItemRegistry.GetData("(O)" + name.FixIdJA()) != null)
+                            pond.fishType.Value = ItemRegistry.GetData("(O)" + name.FixIdJA()).ItemId;
+                        else
+                            pond.fishType.Value = name.FixIdJA();
+                    }
+
                     pond.sign.Value = FixItem(pond.sign.Value) as SObject;
                     pond.output.Value = FixItem(pond.output.Value);
                     pond.neededItem.Value = FixItem(pond.neededItem.Value) as SObject;
@@ -2062,10 +2143,19 @@ namespace JsonAssets
             if (crop is null || crop.indexOfHarvest.Value == null)
                 return;
 
+            // Fix the index of harvest for 1.5.6
             if (this.OldObjectIds.ContainsKey(crop.indexOfHarvest.Value))
                 crop.indexOfHarvest.Value = this.OldObjectIds[crop.indexOfHarvest.Value].FixIdJA("O");
+            // Migrate the index of harvest for 1.6
+            if (Mod.DupObjects.ContainsKey(crop.indexOfHarvest.Value) && crop.indexOfHarvest.Value.FixIdJA("O") != null)
+                crop.indexOfHarvest.Value = crop.indexOfHarvest.Value.FixIdJA("O");
+            // Fix the seed index for 1.5.6
             if (crop.netSeedIndex.Value != null && this.OldObjectIds.ContainsKey(crop.netSeedIndex.Value))
                 crop.netSeedIndex.Value = this.OldObjectIds[crop.netSeedIndex.Value].FixIdJA("O");
+            // Migrate the seed index for 1.6
+            if (crop.netSeedIndex.Value != null && Mod.DupObjects.ContainsKey(crop.netSeedIndex.Value) && crop.netSeedIndex.Value.FixIdJA("O") != null)
+                crop.netSeedIndex.Value = crop.netSeedIndex.Value.FixIdJA("O");
+            // Re-get the seed index if it's null
             if (crop.netSeedIndex.Value == null)
             {
                 foreach (var data in Game1.cropData)
@@ -2078,6 +2168,7 @@ namespace JsonAssets
                 }
             }
 
+            // Set the override texture path for old crops
             if (this.OldCropIds.ContainsKey(crop.rowInSpriteSheet.Value.ToString()))
             {
                 crop.overrideTexturePath.Value = "JA/Crop/" + this.OldCropIds[crop.rowInSpriteSheet.Value.ToString()].FixIdJA("Crop");
@@ -2149,6 +2240,10 @@ namespace JsonAssets
                                 }
                             }
 
+                            // Migrate from previous 1.6
+                            if (Mod.DupObjects.ContainsKey(ftree.treeId.Value) && ftree.treeId.Value.FixIdJA("O") != null)
+                                ftree.treeId.Value = ftree.treeId.Value.FixIdJA("O");
+
                             // Make fruit trees from removed packs at least say their name
                             if (int.TryParse(ftree.obsolete_treeType, out int treeNum1) && this.RemovedFruitTrees.ContainsKey(treeNum1))
                             {
@@ -2206,10 +2301,17 @@ namespace JsonAssets
             var toAdd = new Dictionary<string, int>();
             foreach (string entry in dict.Keys)
             {
+                // Migrate object IDs from 1.5.6
                 if (this.OldObjectIds.ContainsKey(entry))
                 {
                     toRemove.Add(entry);
                     toAdd.TryAdd(this.OldObjectIds[entry].FixIdJA("O"), dict[entry]);
+                }
+                // Migrate from previous 1.6
+                else if (Mod.DupObjects.ContainsKey(entry) && entry.FixIdJA("O") != null)
+                {
+                    toRemove.Add(entry);
+                    toAdd.TryAdd(entry.FixIdJA("O"), dict[entry]);
                 }
             }
             foreach (string entry in toRemove)
@@ -2235,10 +2337,17 @@ namespace JsonAssets
             var toAdd = new Dictionary<string, int[]>();
             foreach (string entry in dict.Keys)
             {
+                // Migrate object IDs from 1.5.6
                 if (this.OldObjectIds.ContainsKey(entry))
                 {
                     toRemove.Add(entry);
                     toAdd.TryAdd(this.OldObjectIds[entry].FixIdJA("O"), dict[entry]);
+                }
+                // Migrate from previous 1.6
+                else if (Mod.DupObjects.ContainsKey(entry) && entry.FixIdJA("O") != null)
+                {
+                    toRemove.Add(entry);
+                    toAdd.TryAdd(entry.FixIdJA("O"), dict[entry]);
                 }
             }
             foreach (string entry in toRemove)
@@ -2259,6 +2368,16 @@ namespace JsonAssets
                     toAdd.TryAdd(entry.FixIdJA("O"), dict[entry]);
                 }
                 else if (this.OldBigCraftableIds.ContainsValue(entry))
+                {
+                    toRemove.Add(entry);
+                    toAdd.TryAdd(entry.FixIdJA("BC"), dict[entry]);
+                }
+                else if (Mod.DupObjects.ContainsKey(entry) && entry.FixIdJA("O") != null)
+                {
+                    toRemove.Add(entry);
+                    toAdd.TryAdd(entry.FixIdJA("O"), dict[entry]);
+                }
+                else if (Mod.DupBigCraftables.ContainsKey(entry) && entry.FixIdJA("BC") != null)
                 {
                     toRemove.Add(entry);
                     toAdd.TryAdd(entry.FixIdJA("BC"), dict[entry]);

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -2400,7 +2400,10 @@ namespace JsonAssets
                             Log.Error("\tobj = " + obj.Name);
                     }
                 }
-                dict.Add(entry.Key, entry.Value);
+                else
+                {
+                    dict.Add(entry.Key, entry.Value);
+                }
             }
         }
     }

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -1283,7 +1283,7 @@ namespace JsonAssets
         [EventPriority(EventPriority.High)]
         private void OnLoadStageChanged(object sender, LoadStageChangedEventArgs e)
         {
-            if (e.NewStage == StardewModdingAPI.Enums.LoadStage.SaveParsed || e.NewStage == StardewModdingAPI.Enums.LoadStage.CreatedSaveFile)
+            if (e.NewStage == StardewModdingAPI.Enums.LoadStage.SaveParsed)
             {
                 //Log.debug("Loading stuff early (loading)");
                 this.InitStuff(loadIdFiles: true);
@@ -1516,6 +1516,8 @@ namespace JsonAssets
                 return;
             this.DidInit = true;
 
+            this.Api.InvokeIdsAssigned();
+
             // load object ID mappings from save folder
             // If loadIdFiles is "maybe" (null), check the current save path
             if (loadIdFiles)
@@ -1634,7 +1636,6 @@ namespace JsonAssets
                     }
                 }
 
-                this.Api.InvokeIdsAssigned();
             }
         }
 

--- a/JsonAssets/Mod.cs
+++ b/JsonAssets/Mod.cs
@@ -1283,7 +1283,7 @@ namespace JsonAssets
         [EventPriority(EventPriority.High)]
         private void OnLoadStageChanged(object sender, LoadStageChangedEventArgs e)
         {
-            if (e.NewStage == StardewModdingAPI.Enums.LoadStage.SaveParsed)
+            if (e.NewStage == StardewModdingAPI.Enums.LoadStage.SaveParsed || e.NewStage == StardewModdingAPI.Enums.LoadStage.CreatedSaveFile)
             {
                 //Log.debug("Loading stuff early (loading)");
                 this.InitStuff(loadIdFiles: true);


### PR DESCRIPTION
- Add optional migrators from the "Item_Name" format to "{{ModId}}_Item_Name" format (all the places marked with a comment as "within 1.6 migration"
- Added a lot of booleans to the migration commands to toggle on/off the more aggressive migrations (the within-1.6 ones and the ones that swap ID for name in the removed JA pack items)
- Added console commands `ja_fix` to trigger migrations and `ja_fix_aggressive` to trigger the aggressive migrations manually, so that the non-aggressive ones run automatically. This is to handle the fact that there's a small edge case where CP-added items with relatively plain names could get accidentally migrated if they overlap with installed JA item names.
- Fix the fruit tree merge conflict properly
- Tailoring recipes now craft the correct item instead of an error item (as long as it's Boots, Pants, Shirts, or an existing item in the game)
- Recipes are now properly fully checking if the ingredients are real items, which hopefully fixes the issue some users have where malformed recipes prevent the cooking menu from opening
- Tokens are now ready for new saves in addition to old saves