### PR TITLE
[Spacecore] Better level up rewards detection and New Reading book patch

### DIFF
--- a/SpaceCore/Interface/SkillLevelUpMenu.cs
+++ b/SpaceCore/Interface/SkillLevelUpMenu.cs
@@ -8,6 +8,7 @@ using Microsoft.Xna.Framework.Input;
 using SpaceShared;
 using StardewValley;
 using StardewValley.Menus;
+using static SpaceCore.Skills;
 
 namespace SpaceCore.Interface
 {
@@ -167,12 +168,9 @@ namespace SpaceCore.Interface
             this.height = num + 256 + this.extraInfoForLevel.Count * 64 * 3 / 4;
             */
 
-            List<CraftingRecipe> levelUpCraftingRecipes =
-                GetCraftingRecipesForLevel(this.currentSkill, this.currentLevel)
-                .ToList()
-                .ConvertAll(name => new CraftingRecipe(name))
-                .Where(recipe => !Game1.player.knowsRecipe(recipe.name))
-                .ToList();
+            //Get Crafting Recipes learned at this level
+            List<CraftingRecipe> levelUpCraftingRecipes = GetCraftingRecipesForLevel(this.currentSkill, this.currentLevel);
+
             if (levelUpCraftingRecipes is not null && levelUpCraftingRecipes.Count > 0)
             {
                 foreach (CraftingRecipe recipe in levelUpCraftingRecipes.Where(r => !Game1.player.craftingRecipes.ContainsKey(r.name)))
@@ -181,12 +179,9 @@ namespace SpaceCore.Interface
                 }
             }
 
-            List<CraftingRecipe> levelUpCookingRecipes =
-                GetCookingRecipesForLevel(this.currentSkill, this.currentLevel)
-                .ToList()
-                .ConvertAll(name => new CraftingRecipe(name))
-                .Where(recipe => !Game1.player.knowsRecipe(recipe.name))
-                .ToList();
+            //Get Cooking Recipes learned at this level
+            List<CraftingRecipe> levelUpCookingRecipes = GetCookingRecipesForLevel(this.currentSkill, this.currentLevel);
+
             if (levelUpCookingRecipes is not null && levelUpCookingRecipes.Count > 0)
             {
                 foreach (CraftingRecipe recipe in levelUpCookingRecipes.Where(r => !Game1.player.cookingRecipes.ContainsKey(r.name)))
@@ -223,6 +218,8 @@ namespace SpaceCore.Interface
             }
             this.populateClickableComponentList();
             this.RepositionOkButton();
+
+
         }
         public override bool overrideSnappyMenuCursorMovementBan()
         {
@@ -320,37 +317,57 @@ namespace SpaceCore.Interface
             */
         }
 
-        public static IReadOnlyList<string> GetCraftingRecipesForLevel(string whichSkill, int level)
+        public static List<CraftingRecipe> GetCraftingRecipesForLevel(string whichSkill, int level)
         {
             // Level used for professions, no new recipes added
+            List<CraftingRecipe> newRecipes = [];
             if (level % 5 == 0)
             {
-                return new List<string>();
+                return newRecipes;
             }
-            var levelUpRecipes = Skills.SkillsByName[whichSkill].GetSkillLevelUpCraftingRecipes(level);
-            // Level undefined
-            if (!levelUpRecipes.ContainsKey(level))
+
+            foreach (KeyValuePair<string, string> recipePair in CraftingRecipe.craftingRecipes)
             {
-                return new List<string>();
+                string conditions = ArgUtility.Get(recipePair.Value.Split('/'), 4, "");
+                if (!conditions.Contains(whichSkill) || !conditions.Contains(level.ToString()))
+                {
+                    continue;
+                }
+
+                CraftingRecipe recipe = new(recipePair.Key, isCookingRecipe: false);
+                newRecipes.Add(recipe);
+                Game1.player.craftingRecipes.TryAdd(recipePair.Key, 0);
             }
-            return (IReadOnlyList<string>)levelUpRecipes[level];
+            return newRecipes;
         }
 
-        public static IReadOnlyList<string> GetCookingRecipesForLevel(string whichSkill, int level)
+        public static List<CraftingRecipe> GetCookingRecipesForLevel(string whichSkill, int level)
         {
             // Level used for professions, no new recipes added
+            List<CraftingRecipe> newRecipes = [];
             if (level % 5 == 0)
             {
-                return new List<string>();
+                return newRecipes;
             }
-            var levelUpRecipes = Skills.SkillsByName[whichSkill].GetSkillLevelUpCookingRecipes(level);
-            // Level undefined
-            if (!levelUpRecipes.ContainsKey(level))
+            foreach (KeyValuePair<string, string> recipePair in CraftingRecipe.cookingRecipes)
             {
-                return new List<string>();
+                string conditions = ArgUtility.Get(recipePair.Value.Split('/'), 3, "");
+                if (!conditions.Contains(whichSkill) || !conditions.Contains(level.ToString()))
+                {
+                    continue;
+                }
+
+                CraftingRecipe recipe = new(recipePair.Key, isCookingRecipe: true);
+                newRecipes.Add(recipe);
+                if (Game1.player.cookingRecipes.TryAdd(recipePair.Key, 0) &&
+                    !Game1.player.hasOrWillReceiveMail("robinKitchenLetter"))
+                {
+                    Game1.mailbox.Add("robinKitchenLetter");
+                }
+
             }
 
-            return (IReadOnlyList<string>)levelUpRecipes[level];
+            return newRecipes;
         }
 
         private static void addProfessionDescriptions(List<string> descriptions, string professionName)
@@ -505,6 +522,13 @@ namespace SpaceCore.Interface
             else
                 Game1.player.maxHealth += 15;
             */
+
+            //This was missing when compared to vanilla perks. When ever you level up in a skill,
+            // you always gained maxd stamina and health, even if you exhaust yourself.
+
+
+            Game1.player.health = Game1.player.maxHealth;
+            Game1.player.stamina = Game1.player.MaxStamina;
         }
 
         public override void update(GameTime time)

--- a/SpaceCore/Patches/ReadBookPatcher.cs
+++ b/SpaceCore/Patches/ReadBookPatcher.cs
@@ -32,22 +32,35 @@ namespace SpaceCore.Patches
 
             bool customSkillbook = false;
 
-            //Go through each skill in the skill list that is loaded with space core
-            foreach(string skill in Skills.GetSkillList())
+            //First, we check to see if the book being used is the book of stars.
+            if (__instance.Name == "Book Of Stars")
             {
-                Log.Trace("For Each loop of reading the book. here is a list of custom skill: " + skill);
-                //If we found a book that has the skill ID as a tag continue
-                if (__instance.HasContextTag(skill))
+                //If it is, the book of stars is meant to give every skill 250 exp. So we look through all the skills here and grant it exp.
+                //We don't want to cancel the normal behavior of the book of stars, so we don't set custom book = true.
+                foreach (string skill in Skills.GetSkillList())
                 {
+                    Skills.AddExperience(Game1.player, skill, 250);
+                }
 
-                    Log.Trace("Found a custom tag for skill: " + skill+". Adding exp to it");
-
-                    //Copied from Vanilla
-                    Game1.player.canMove = false;
-                    Game1.player.freezePause = 1030;
-                    Game1.player.faceDirection(2);
-                    Game1.player.FarmerSprite.animateOnce(new FarmerSprite.AnimationFrame[1]
+                //If it isn't the book of stars, we then check the context tags of the book
+            } else
+            {
+                //Go through each skill in the skill list that is loaded with space core
+                foreach (string skill in Skills.GetSkillList())
+                {
+                    Log.Trace("For Each loop of reading the book. here is a list of custom skill: " + skill);
+                    //If we found a book that has the skill ID as a tag continue
+                    if (__instance.HasContextTag(skill))
                     {
+    
+                        Log.Trace("Found a custom tag for skill: " + skill + ". Adding exp to it");
+    
+                        //Copied from Vanilla
+                        Game1.player.canMove = false;
+                        Game1.player.freezePause = 1030;
+                        Game1.player.faceDirection(2);
+                        Game1.player.FarmerSprite.animateOnce(new FarmerSprite.AnimationFrame[1]
+                        {
                     new FarmerSprite.AnimationFrame(57, 1000, secondaryArm: false, flip: false, Farmer.canMoveNow, behaviorAtEndOfFrame: true)
                     {
                         frameEndBehavior = delegate
@@ -56,46 +69,49 @@ namespace SpaceCore.Patches
                             Utility.addRainbowStarExplosion(location, Game1.player.getStandingPosition() + new Vector2(-40f, -156f), 8);
                         }
                     }
-                    });
-                    Game1.MusicDuckTimer = 4000f;
-                    Game1.playSound("book_read");
-                    Game1.Multiplayer.broadcastSprites(location, new TemporaryAnimatedSprite("LooseSprites\\Book_Animation", new Microsoft.Xna.Framework.Rectangle(0, 0, 20, 20), 10f, 45, 1, Game1.player.getStandingPosition() + new Vector2(-48f, -156f), flicker: false, flipped: false, Game1.player.getDrawLayer() + 0.001f, 0f, Color.White, 4f, 0f, 0f, 0f)
-                    {
-                        holdLastFrame = true,
-                        id = 1987654
-                    });
-                    Color? colorFromTags = ItemContextTagManager.GetColorFromTags(__instance);
-                    if (colorFromTags.HasValue)
-                    {
-                        Game1.Multiplayer.broadcastSprites(location, new TemporaryAnimatedSprite("LooseSprites\\Book_Animation", new Microsoft.Xna.Framework.Rectangle(0, 20, 20, 20), 10f, 45, 1, Game1.player.getStandingPosition() + new Vector2(-48f, -156f), flicker: false, flipped: false, Game1.player.getDrawLayer() + 0.0012f, 0f, colorFromTags.Value, 4f, 0f, 0f, 0f)
+                        });
+                        Game1.MusicDuckTimer = 4000f;
+                        Game1.playSound("book_read");
+                        Game1.Multiplayer.broadcastSprites(location, new TemporaryAnimatedSprite("LooseSprites\\Book_Animation", new Microsoft.Xna.Framework.Rectangle(0, 0, 20, 20), 10f, 45, 1, Game1.player.getStandingPosition() + new Vector2(-48f, -156f), flicker: false, flipped: false, Game1.player.getDrawLayer() + 0.001f, 0f, Color.White, 4f, 0f, 0f, 0f)
                         {
                             holdLastFrame = true,
                             id = 1987654
                         });
+                        Color? colorFromTags = ItemContextTagManager.GetColorFromTags(__instance);
+                        if (colorFromTags.HasValue)
+                        {
+                            Game1.Multiplayer.broadcastSprites(location, new TemporaryAnimatedSprite("LooseSprites\\Book_Animation", new Microsoft.Xna.Framework.Rectangle(0, 20, 20, 20), 10f, 45, 1, Game1.player.getStandingPosition() + new Vector2(-48f, -156f), flicker: false, flipped: false, Game1.player.getDrawLayer() + 0.0012f, 0f, colorFromTags.Value, 4f, 0f, 0f, 0f)
+                            {
+                                holdLastFrame = true,
+                                id = 1987654
+                            });
+                        }
+    
+                        int count = Game1.player.newLevels.Count;
+                        //Add skill exp, vanilla has it be 250
+                        Skills.AddExperience(Game1.player, skill, 250);
+    
+                        //Code to send a message if the player's level has changed to sleep.
+                        // disabled for now
+                        ///if (Game1.player.newLevels.Count == count || (Game1.player.newLevels.Count > 1 && count >= 1))
+                        ///{
+                        ///    DelayedAction.functionAfterDelay(delegate
+                        ///    {
+                        ///        Game1.showGlobalMessage(Game1.content.LoadString("Strings\\1_6_Strings:SkillBookMessage", Game1.content.LoadString("Strings\\1_6_Strings:SkillName_" + base.ItemId.Last()).ToLower()));
+                        ///    }, 1000);
+                        ///}
+                        ///
+    
+                        //Break the foreach loop after setting that we found a custom skillbook
+                        customSkillbook = true;
+                        break;
                     }
-
-                    int count = Game1.player.newLevels.Count;
-                    //Add skill exp, vanilla has it be 250
-                    Skills.AddExperience(Game1.player, skill, 250);
-
-                    //Code to send a message if the player's level has changed to sleep.
-                    // disabled for now
-                    ///if (Game1.player.newLevels.Count == count || (Game1.player.newLevels.Count > 1 && count >= 1))
-                    ///{
-                    ///    DelayedAction.functionAfterDelay(delegate
-                    ///    {
-                    ///        Game1.showGlobalMessage(Game1.content.LoadString("Strings\\1_6_Strings:SkillBookMessage", Game1.content.LoadString("Strings\\1_6_Strings:SkillName_" + base.ItemId.Last()).ToLower()));
-                    ///    }, 1000);
-                    ///}
-                    ///
-
-                    //Break the foreach loop after setting that we found a custom skillbook
-                    customSkillbook = true;
-                    break;
+    
                 }
-
             }
 
+            //If it is a custom skill, we don't want to continue the read book function
+            // so we return false to cancel the rest of it.
             if (customSkillbook)
             {
                 return false;

--- a/SpaceCore/Patches/ReadBookPatcher.cs
+++ b/SpaceCore/Patches/ReadBookPatcher.cs
@@ -30,14 +30,20 @@ namespace SpaceCore.Patches
             //Here is a universal patch for players to add EXP books
             //For it to work, players will have to add a tag to their exp book that has their skill ID
 
+            //Make a variable to see if we have found a custom book and have it be false for now.
             bool customSkillbook = false;
+
+
 
             //First, we check to see if the book being used is the book of stars.
             if (__instance.Name == "Book Of Stars")
             {
                 //If it is, the book of stars is meant to give every skill 250 exp. So we look through all the skills here and grant it exp.
                 //We don't want to cancel the normal behavior of the book of stars, so we don't set custom book = true.
-                foreach (string skill in Skills.GetSkillList())
+
+                //We only want to apply exp from the book of stars if the skill is visible to the player.
+                string[] VisibleSkills = Skills.GetSkillList().Where(s => Skills.GetSkill(s).ShouldShowOnSkillsPage).ToArray();
+                foreach (string skill in VisibleSkills)
                 {
                     Skills.AddExperience(Game1.player, skill, 250);
                 }

--- a/SpaceCore/Patches/ReadBookPatcher.cs
+++ b/SpaceCore/Patches/ReadBookPatcher.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HarmonyLib;
+using Microsoft.Xna.Framework;
+using Spacechase.Shared.Patching;
+using SpaceShared;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Menus;
+
+namespace SpaceCore.Patches
+{
+    internal class ReadBookPatcher : BasePatcher
+    {
+        public override void Apply(Harmony harmony, IMonitor monitor)
+        {
+            harmony.Patch(
+                original: this.RequireMethod<StardewValley.Object>("readBook"),
+                prefix: this.GetHarmonyMethod(nameof(Before_ReadBook))
+            );
+        }
+
+        public static bool Before_ReadBook(StardewValley.Object __instance, GameLocation location)
+        {
+
+            //Players can only "read books" Objects if they are the right catagory.
+            //Here is a universal patch for players to add EXP books
+            //For it to work, players will have to add a tag to their exp book that has their skill ID
+
+            bool customSkillbook = false;
+
+            //Go through each skill in the skill list that is loaded with space core
+            foreach(string skill in Skills.GetSkillList())
+            {
+                Log.Trace("For Each loop of reading the book. here is a list of custom skill: " + skill);
+                //If we found a book that has the skill ID as a tag continue
+                if (__instance.HasContextTag(skill))
+                {
+
+                    Log.Trace("Found a custom tag for skill: " + skill+". Adding exp to it");
+
+                    //Copied from Vanilla
+                    Game1.player.canMove = false;
+                    Game1.player.freezePause = 1030;
+                    Game1.player.faceDirection(2);
+                    Game1.player.FarmerSprite.animateOnce(new FarmerSprite.AnimationFrame[1]
+                    {
+                    new FarmerSprite.AnimationFrame(57, 1000, secondaryArm: false, flip: false, Farmer.canMoveNow, behaviorAtEndOfFrame: true)
+                    {
+                        frameEndBehavior = delegate
+                        {
+                            location.removeTemporarySpritesWithID(1987654);
+                            Utility.addRainbowStarExplosion(location, Game1.player.getStandingPosition() + new Vector2(-40f, -156f), 8);
+                        }
+                    }
+                    });
+                    Game1.MusicDuckTimer = 4000f;
+                    Game1.playSound("book_read");
+                    Game1.Multiplayer.broadcastSprites(location, new TemporaryAnimatedSprite("LooseSprites\\Book_Animation", new Microsoft.Xna.Framework.Rectangle(0, 0, 20, 20), 10f, 45, 1, Game1.player.getStandingPosition() + new Vector2(-48f, -156f), flicker: false, flipped: false, Game1.player.getDrawLayer() + 0.001f, 0f, Color.White, 4f, 0f, 0f, 0f)
+                    {
+                        holdLastFrame = true,
+                        id = 1987654
+                    });
+                    Color? colorFromTags = ItemContextTagManager.GetColorFromTags(__instance);
+                    if (colorFromTags.HasValue)
+                    {
+                        Game1.Multiplayer.broadcastSprites(location, new TemporaryAnimatedSprite("LooseSprites\\Book_Animation", new Microsoft.Xna.Framework.Rectangle(0, 20, 20, 20), 10f, 45, 1, Game1.player.getStandingPosition() + new Vector2(-48f, -156f), flicker: false, flipped: false, Game1.player.getDrawLayer() + 0.0012f, 0f, colorFromTags.Value, 4f, 0f, 0f, 0f)
+                        {
+                            holdLastFrame = true,
+                            id = 1987654
+                        });
+                    }
+
+                    int count = Game1.player.newLevels.Count;
+                    //Add skill exp, vanilla has it be 250
+                    Skills.AddExperience(Game1.player, skill, 250);
+
+                    //Code to send a message if the player's level has changed to sleep.
+                    // disabled for now
+                    ///if (Game1.player.newLevels.Count == count || (Game1.player.newLevels.Count > 1 && count >= 1))
+                    ///{
+                    ///    DelayedAction.functionAfterDelay(delegate
+                    ///    {
+                    ///        Game1.showGlobalMessage(Game1.content.LoadString("Strings\\1_6_Strings:SkillBookMessage", Game1.content.LoadString("Strings\\1_6_Strings:SkillName_" + base.ItemId.Last()).ToLower()));
+                    ///    }, 1000);
+                    ///}
+                    ///
+
+                    //Break the foreach loop after setting that we found a custom skillbook
+                    customSkillbook = true;
+                    break;
+                }
+
+            }
+
+            if (customSkillbook)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/SpaceCore/Skills.cs
+++ b/SpaceCore/Skills.cs
@@ -76,15 +76,11 @@ namespace SpaceCore
 
             public Color ExperienceBarColor { get; set; }
 
-            public virtual IDictionary<int, IList<string>> GetSkillLevelUpCraftingRecipes(int level)
-            {
-                return new Dictionary<int, IList<string>>();
-            }
-
-            public virtual IDictionary<int, IList<string>> GetSkillLevelUpCookingRecipes(int level)
-            {
-                return new Dictionary<int, IList<string>>();
-            }
+            /// 
+            /// Got Rid of the level up Dictionaries.
+            /// Now when the player levels up, custom skills will search all the recipes for recipes with thier ID and level
+            /// So now it's easier for people to add new recipies to skills through like content patcher
+            /// 
 
 
             public virtual List<string> GetExtraLevelUpInfo(int level)

--- a/SpaceCore/SpaceCore.cs
+++ b/SpaceCore/SpaceCore.cs
@@ -264,6 +264,7 @@ namespace SpaceCore
                 new LoadGameMenuPatcher(serializerManager),
                 new MultiplayerPatcher(),
                 new NpcPatcher(),
+                new ReadBookPatcher(),
                 new SaveGamePatcher(serializerManager),
                 new SerializationPatcher(),
                 new UtilityPatcher(),

--- a/SpaceCore/docs/README.md
+++ b/SpaceCore/docs/README.md
@@ -196,6 +196,9 @@ The rest of the features assume you understand C# and the game code a little bit
     * `string GetSkillPageHoverText(int level)` - optional, extra text to show when hovering on the skills page
     * `void DoLevelPerk(int level)` - optional, apply a some code immediately upon leveling
     * `bool ShouldShowOnSkillsPage`
+    * Custom buffs for your skill you can have by adding ` "spacechase.SpaceCore.SkillBuff.<skill_ID_here>": "<value>"` as a custom field to the buff for food or drink.
+    * Your custom skill can have level up crafting and cooking recipes by just adding your skill ID to where the vanilla skill ID would be.
+    * By adding the skill id to the context tags of a book object, players can read the book to gain exp in the custom skill.
 * Custom crafting recipes, for when you want more flexibility (like using non-Object item types).
     * You subclass `CustomCraftingRecipe` and register it by doing `CustomCraftingRecipe.CraftingRecipes.Add( key, new MyCustomCraftingRecipeSubclass() )`.
         * If it is a cooking recipe, you use `CustomCraftingRecipe.CookingRecipes` instead.


### PR DESCRIPTION
This Pull request contains three things...

1. Redid the level up crafting/cooking rewards I did back in #347. No longer does the modder need to define the level up recipes in a dictionary. Now we just scan the recipe list for the crafting/cooking recipes for those that have the the skill ID in the level up slot. 

2. Added a Full heal/Energy restore on levelup of a custom skill. Apparently it's a vanilla thing that custom skills don't do, so this is parity with vanilla.

3. Added a new Patcher: Before_Readbook. This patcher gathers a list of all custom skills and searches the context tags for the mod-ID of the current book being read. If it finds this ID, it then gives the player exp to the custom skill. I added this to SpaceCore since the custom skills here are trying to Emulate vanilla. It would be annoying if each custom skill that wants a skill book with it has to basically copy-paste the code. 

4. The above patcher also adds parity with custom skills and the book of stars. Book of stars grants 250 exp to every skill in vanilla. That said, it will only give exp to skills that have the visible tag.