### PR TITLE
[Spacecore] Skill mastery exp for custom skills

### DIFF
--- a/SpaceCore/Skills.cs
+++ b/SpaceCore/Skills.cs
@@ -325,7 +325,8 @@ namespace SpaceCore
 
             ///Taken From Vanilla
             ///Mastery Exp is added before exp to the skill is added
-            ///First, we check to see if the skill we are gaining exp in is 10. If they are not 10 or greater than 10 (if a mod has a prestige system), then don't add mastery exp
+            ///First, we check to see if the skill we are gaining exp in is >=10.
+            ///If they are not 10 or greater than 10 (if a mod has a prestige system), then don't add mastery exp
             ///Next, we check to see of the Core skills (vanilla skills) of the farmer equal 25. If so that means they are maxed out on them.
             int level = (farmer.farmingLevel.Value + farmer.fishingLevel.Value + farmer.foragingLevel.Value + farmer.combatLevel.Value + farmer.miningLevel.Value) / 2;
             if (prevLevel >= 10 && level >= 25)

--- a/SpaceCore/Skills.cs
+++ b/SpaceCore/Skills.cs
@@ -322,6 +322,24 @@ namespace SpaceCore
             Skills.ValidateSkill(farmer, skillName);
 
             int prevLevel = Skills.GetSkillLevel(farmer, skillName);
+
+            ///Taken From Vanilla
+            ///Mastery Exp is added before exp to the skill is added
+            ///First, we check to see if the skill we are gaining exp in is 10. If they are not 10 or greater than 10 (if a mod has a prestige system), then don't add mastery exp
+            ///Next, we check to see of the Core skills (vanilla skills) of the farmer equal 25. If so that means they are maxed out on them.
+            int level = (farmer.farmingLevel.Value + farmer.fishingLevel.Value + farmer.foragingLevel.Value + farmer.combatLevel.Value + farmer.miningLevel.Value) / 2;
+            if (prevLevel >= 10 && level >= 25)
+            {
+                ///All thise here is just how vanilla does thier mastery exp system. So it's just copy past with the amount. 
+                int currentMasteryLevel = MasteryTrackerMenu.getCurrentMasteryLevel();
+                Game1.stats.Increment("MasteryExp", Math.Max(1, amt / 2));
+                if (MasteryTrackerMenu.getCurrentMasteryLevel() > currentMasteryLevel)
+                {
+                    Game1.showGlobalMessage(Game1.content.LoadString("Strings\\1_6_Strings:Mastery_newlevel"));
+                    Game1.playSound("newArtifact");
+                }
+            }
+
             Skills.Exp[farmer.UniqueMultiplayerID][skillName] += amt;
             if (farmer == Game1.player && prevLevel != Skills.GetSkillLevel(farmer, skillName))
                 for (int i = prevLevel + 1; i <= Skills.GetSkillLevel(farmer, skillName); ++i)


### PR DESCRIPTION
Changes from the title should be pretty self explanatory. 

Adds a Check to the `AddExperince` function of `Skills`

1. Gathers the player's Core skill level and see if they are maxed
2. Checks to see if the custom skill they are gaining exp in is also max or above max
3. Gives mastery exp if the above two are true.

Added this here to Spacecore so not every custom skill needs to worry about how they are going to do mastery exp. It would be a lot of redundant code. 