### PR TITLE
[Spacecore] Api summery + skill icon request

### DIFF
--- a/SpaceCore/Api.cs
+++ b/SpaceCore/Api.cs
@@ -57,6 +57,13 @@ namespace SpaceCore
         /// <param name="farmer"> The farmer you want the list for</param>
         /// <returns>List<Tuple<skill, XP value, Level>></returns>
         List<Tuple<string, int, int>> GetExperienceAndLevelsForCustomSkill(Farmer farmer);
+
+        /// <summary>
+        /// Add EXP to a custom skill
+        /// </summary>
+        /// <param name="farmer"> The farmer who you want to give exp to</param>
+        /// <param name="skill"> The string ID of the custom skill</param>
+        /// <param name="amt"> The int Amount you want to give</param>
         void AddExperienceForCustomSkill(Farmer farmer, string skill, int amt);
 
         /// <summary>

--- a/SpaceCore/Api.cs
+++ b/SpaceCore/Api.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Xml.Serialization;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using SpaceCore.Patches;
 using SpaceShared;
 using StardewValley;
@@ -12,11 +13,72 @@ namespace SpaceCore
 {
     public interface IApi
     {
+        /// <summary>
+        /// Returns a list of all currently loaded skill's string IDs
+        /// </summary>
+        /// <returns>An array of skill IDs</returns>
         string[] GetCustomSkills();
+
+        /// <summary>
+        /// Gets the Base level of the custom skill for the farmer.
+        /// </summary>
+        /// <param name="farmer"> The farmer who you want to get the skill level for.</param>
+        /// <param name="skill"> The string ID of the skill you want the level of.</param>
+        /// <returns>Int</returns>
         int GetLevelForCustomSkill(Farmer farmer, string skill);
+
+        /// <summary>
+        /// Gets the Buff level of the custom skill for the farmer.
+        /// </summary>
+        /// <param name="farmer"> The farmer who you want to get the skill level for.</param>
+        /// <param name="skill"> The string ID of the skill you want the level of.</param>
+        /// <returns>Int</returns>
+        int GetBuffLevelForCustomSkill(Farmer farmer, string skill);
+
+        /// <summary>
+        /// Gets the Base + Buff level of the custom skill for the farmer.
+        /// </summary>
+        /// <param name="farmer"> The farmer who you want to get the skill level for.</param>
+        /// <param name="skill"> The string ID of the skill you want the level of.</param>
+        /// <returns>Int</returns>
+        int GetTotalLevelForCustomSkill(Farmer farmer, string skill);
+
+        /// <summary>
+        /// Gets the total exp the skill has
+        /// </summary>
+        /// <param name="farmer"> The farmer who you want to get the skill level for.</param>
+        /// <param name="skill"> The string ID of the skill you want the level of.</param>
+        /// <returns>Int</returns>
         int GetExperienceForCustomSkill(Farmer farmer, string skill);
+
+        /// <summary>
+        /// Get a list of all the skills with the ID, current xp value in them, and current level
+        /// </summary>
+        /// <param name="farmer"> The farmer you want the list for</param>
+        /// <returns>List<Tuple<skill, XP value, Level>></returns>
         List<Tuple<string, int, int>> GetExperienceAndLevelsForCustomSkill(Farmer farmer);
         void AddExperienceForCustomSkill(Farmer farmer, string skill, int amt);
+
+        /// <summary>
+        /// Gets the 10x10 icon of the skill that shows up on the skill page
+        /// </summary>
+        /// <param name="skill"> The ID of the skill you want to get</param>
+        /// <returns>Texture2D</returns>
+        Texture2D GetSkillPageIconForCustomSkill(string skill);
+
+        /// <summary>
+        /// Gets the 16x16 icon of the skill that shows up in the level up menu.
+        /// </summary>
+        /// <param name="skill"> The ID of the skill you want to get</param>
+        /// <returns>Texture2D</returns>
+        Texture2D GetSkillIconForCustomSkill(string skill);
+
+        /// <summary>
+        /// Get the profession ID for the custom skill
+        /// </summary>
+        /// <param name="skill"></param>
+        /// <param name="profession"></param>
+        /// <returns>int profession ID</returns>
         int GetProfessionId(string skill, string profession);
 
         /// Must have [XmlType("Mods_SOMETHINGHERE")] attribute (required to start with "Mods_")
@@ -39,6 +101,16 @@ namespace SpaceCore
             return Skills.GetSkillLevel(farmer, skill);
         }
 
+        public int GetBuffLevelForCustomSkill(Farmer farmer, string skill)
+        {
+            return Skills.GetSkillBuffLevel(farmer, skill);
+        }
+
+        public int GetTotalLevelForCustomSkill(Farmer farmer, string skill)
+        {
+            return Skills.GetSkillBuffLevel(farmer, skill) + Skills.GetSkillLevel(farmer, skill);
+        }
+
         public int GetExperienceForCustomSkill(Farmer farmer, string skill)
         {
             return farmer.GetCustomSkillExperience(skill);
@@ -52,6 +124,16 @@ namespace SpaceCore
         public void AddExperienceForCustomSkill(Farmer farmer, string skill, int amt)
         {
             farmer.AddCustomSkillExperience(skill, amt);
+        }
+
+        public Texture2D GetSkillPageIconForCustomSkill(string skill)
+        {
+            return Skills.GetSkillPageIcon(skill);
+        }
+
+        public Texture2D GetSkillIconForCustomSkill(string skill)
+        {
+            return Skills.GetSkillIcon(skill);
         }
 
         public int GetProfessionId(string skill, string profession)

--- a/SpaceCore/Skills.cs
+++ b/SpaceCore/Skills.cs
@@ -262,6 +262,16 @@ namespace SpaceCore
             return forFarmer;
         }
 
+        public static Texture2D GetSkillPageIcon(string skillName)
+        {
+            return Skills.GetSkill(skillName).SkillsPageIcon;
+        }
+
+        public static Texture2D GetSkillIcon(string skillName)
+        {
+            return Skills.GetSkill(skillName).Icon;
+        }
+
         public static int GetExperienceFor(Farmer farmer, string skillName)
         {
             if (!Skills.SkillsByName.ContainsKey(skillName))

--- a/SpaceCore/docs/README.md
+++ b/SpaceCore/docs/README.md
@@ -127,8 +127,12 @@ Provided functionality for content pack authors:
 The rest of the features assume you understand C# and the game code a little bit (and are only accessible via C#):
 * In the API provided through SMAPI's mod registry (see mod source for interface you can copy):
     * `string[] GetCustomSkills()` - Returns an array of skill IDs, one for each registered skill.
-    * `int GetLevelForCustomSkill(Farmer farmer, string skill)` - Gets the level of the given `skill` for the given `farmer`.
+    * `int GetLevelForCustomSkill(Farmer farmer, string skill)` - Gets the base level of the given `skill` for the given `farmer`.
+    * `int GetBuffLevelForCustomSkill(Farmer farmer, string skill)` - Gets the buff level of the given `skill` for the given `farmer`.
+    * `int GetTotalLevelForCustomSkill(Farmer farmer, string skill)` - Gets the base + buff level of the given `skill` for the given `farmer`.
     * `void AddExperienceForCustomSkill(Farmer farmer, string skill, int amt)` - Adds `amt` experience to the given `skill` for the given `farmer`.
+    * `Texture2D GetSkillPageIconForCustomSkill(string skill)` - Gets the skill page icon for the given `skill`.
+    * `Texture2D GetSkillIconForCustomSkill(string skill)` - Gets the skill icon for the given `skill`.
     * `int GetProfessionId(string skill, string profession)` - Gets the integer ID of the given `profession` (for `Farmer.professions`) for the given skill.
     * `void RegisterSerializerType(Type type)` - Register a `type` as being valid for the vanilla serializer. Must have the attribute `XmlType` applied, with the parameter starting with `"Mods_"`, ie. `[XmlType("Mods_AuthorName_MyCustomObject")]`.
     * `void RegisterCustomProperty(Type declaringType, string name, Type propType, MethodInfo getter, MethodInfo setter)` - Register a virtual property, attaching itself to a vanilla object for serialization.


### PR DESCRIPTION
Added ///summery to most of the API functions.

Also added the following things to the API

1. GetBuffLevelForCustomSkill: Returns the current buff amount for a custom skill
2. GetTotalLevelForCustomSkill: Returns base level + buff level for a custom skill
3. GetSkillPageIconForCustomSkill: Returns the skill page icon for a custom skill
4. GetSkillIconForCustomSkill: Returns the skill icon for a custom skill

This will complete issue #453