### PR TITLE
[SpaceCore] Fallback for Recipe Descriptions and Fix Double Ingredient Count

### DIFF
--- a/SpaceCore/Framework/CustomCraftingRecipe.cs
+++ b/SpaceCore/Framework/CustomCraftingRecipe.cs
@@ -18,7 +18,7 @@ namespace SpaceCore.Framework
             if (this.recipe.Name != null)
                 this.DisplayName = this.recipe.Name;
 
-            if (this.recipe.Description.Length > 0)
+            if (this.recipe.Description == null || this.recipe.Description.Length > 0)
                 this.description = this.recipe.Description;
         }
 
@@ -63,7 +63,7 @@ namespace SpaceCore.Framework
                 required_count -= bag_count;
                 if (additional_crafting_items != null)
                 {
-                    containers_count = ingred.GetAmountInList(Game1.player.Items);
+                    containers_count = ingred.GetAmountInList(additional_crafting_items);
                     if (required_count > 0)
                     {
                         required_count -= containers_count;

--- a/SpaceCore/Framework/CustomCraftingRecipe.cs
+++ b/SpaceCore/Framework/CustomCraftingRecipe.cs
@@ -17,6 +17,9 @@ namespace SpaceCore.Framework
             this.recipe = recipeOverride;
             if (this.recipe.Name != null)
                 this.DisplayName = this.recipe.Name;
+
+            if (this.recipe.Description.Length > 0)
+                this.description = this.recipe.Description;
         }
 
         public override Item createItem()
@@ -80,7 +83,7 @@ namespace SpaceCore.Framework
                 }
             }
             b.Draw(Game1.staminaRect, new Rectangle((int)position.X + 8, (int)position.Y + lineExpansion + 64 + 4 + this.recipe.Ingredients.Length * 36, width - 32, 2), Game1.textColor * 0.35f);
-            Utility.drawTextWithShadow(b, Game1.parseText(this.recipe.Description, Game1.smallFont, width - 8), Game1.smallFont, position + new Vector2(0f, 76 + this.recipe.Ingredients.Length * 36 + lineExpansion), Game1.textColor * 0.75f);
+            Utility.drawTextWithShadow(b, Game1.parseText(this.description, Game1.smallFont, width - 8), Game1.smallFont, position + new Vector2(0f, 76 + this.recipe.Ingredients.Length * 36 + lineExpansion), Game1.textColor * 0.75f);
         }
 
         public override int getCraftableCount(IList<Chest> additional_material_chests)


### PR DESCRIPTION
Resolves #459 

If the provided `recipeOverride` in the `SpaceCore.Framework.CustomCraftingRecipe` constructor has an empty description, it now does not display an empty space where the description should go. It now falls back on the vanilla game's `CraftingRecipe.description` field, which is auto-populated with the output item's description.

The changes in the constructor ensure that vanilla methods like `CraftingRecipe.getDescriptionHeight` use the right data. (Currently, if `CraftingRecipe.description` is two lines but `recipeOverride.Description` is one line, space for two lines will be allocated when only one is needed).

I don't think `VAECraftingRecipe.Description` has any more references in `SpaceCore` now that this one was removed, but I did not delete it because I don't know what else outside of `SpaceCore` may rely on it.

Additionally, fixed the bug where the number of ingredients shown was doubled because it checked the player's inventory twice rather than checking the inventory AND the additional containers.