### PR TITLE
[SpaceCore] Check if the asset exists before adding a locale name to the animation target

### DIFF
--- a/SpaceCore/VanillaAssetExpansion/VanillaAssetExpansion.cs
+++ b/SpaceCore/VanillaAssetExpansion/VanillaAssetExpansion.cs
@@ -307,7 +307,9 @@ namespace SpaceCore.VanillaAssetExpansion
 
                 foreach (var tex in texs)
                 {
-                    tex.Value.TargetTexture += localeStr;
+                    string localeTex = tex.Value.TargetTexture + localeStr;
+                    if (Instance.Helper.GameContent.DoesAssetExist<Texture2D>(Instance.Helper.GameContent.ParseAssetName(localeTex)))
+                        tex.Value.TargetTexture = localeTex;
                     if (!SpriteBatchPatcher.packOverrides.ContainsKey(tex.Value.TargetTexture))
                         SpriteBatchPatcher.packOverrides.Add(tex.Value.TargetTexture, new());
                     SpriteBatchPatcher.packOverrides[tex.Value.TargetTexture].Add(tex.Value.TargetRect, tex.Value);


### PR DESCRIPTION
This is a further fix to PR #472, which fixes an issue where animations do not work in non-English languages by adding locale name to animation target.
However, Space Core should check for the existence of assets with the locale name appended before adding it, as many `TileSheets` used by the game are identical across all languages (e.g. `TileSheets/Craftables`).
I've tested this fix on my own games and it seems to work well.