### PR TITLE
Add SubHeader label to GMCM

### DIFF
--- a/GenericModConfigMenu/Framework/Api.cs
+++ b/GenericModConfigMenu/Framework/Api.cs
@@ -80,6 +80,16 @@ namespace GenericModConfigMenu.Framework
         }
 
         /// <inheritdoc />
+        public void AddSubHeader(IManifest mod, Func<string> text)
+        {
+            mod ??= this.mod;
+            this.AssertNotNull(text);
+
+            ModConfig modConfig = this.ConfigManager.Get(mod, assert: true);
+            modConfig.AddOption(new SectionSubHeaderModOption(text, modConfig));
+        }
+
+        /// <inheritdoc />
         public void AddParagraph(IManifest mod, Func<string> text)
         {
             mod ??= this.mod;

--- a/GenericModConfigMenu/Framework/ModOption/SectionSubHeaderModOption.cs
+++ b/GenericModConfigMenu/Framework/ModOption/SectionSubHeaderModOption.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace GenericModConfigMenu.Framework.ModOption
+{
+    /// <summary>A mod option which renders a sub-header in a config section.</summary>
+    internal class SectionSubHeaderModOption : ReadOnlyModOption
+    {
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="text">The title text to show in the form.</param>
+        /// <param name="mod">The mod config UI that contains this option.</param>
+        public SectionSubHeaderModOption(Func<string> text, ModConfig mod)
+            : base(text, null, mod) { }
+    }
+}

--- a/GenericModConfigMenu/Framework/SpecificModConfigMenu.cs
+++ b/GenericModConfigMenu/Framework/SpecificModConfigMenu.cs
@@ -359,6 +359,15 @@ namespace GenericModConfigMenu.Framework
                         optionElement = null;
                         break;
 
+                    case SectionSubHeaderModOption _:
+                        label.LocalPosition = new Vector2(-8, 0);
+                        label.Bold = true;
+                        label.Scale = 0.75f;
+                        if (name == "")
+                            label = null;
+                        optionElement = null;
+                        break;
+
                     case PageLinkModOption option:
                         label.Bold = true;
                         label.Callback = _ => this.OpenPage(option.PageId);

--- a/GenericModConfigMenu/IGenericModConfigMenuApi.cs
+++ b/GenericModConfigMenu/IGenericModConfigMenuApi.cs
@@ -36,6 +36,12 @@ namespace GenericModConfigMenu
         /// <param name="tooltip">The tooltip text shown when the cursor hovers on the title, or <c>null</c> to disable the tooltip.</param>
         void AddSectionTitle(IManifest mod, Func<string> text, Func<string> tooltip = null);
 
+        /// <summary>Add a subheader at the current position in the form.</summary>
+        /// <remarks>Larger than paragraph, smaller than title.</remarks>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="text">The title text shown in the form.</param>
+        void AddSubHeader(IManifest mod, Func<string> text);
+
         /// <summary>Add a paragraph of text at the current position in the form.</summary>
         /// <param name="mod">The mod's manifest.</param>
         /// <param name="text">The paragraph text to display.</param>

--- a/SpaceShared/UI/Label.cs
+++ b/SpaceShared/UI/Label.cs
@@ -19,14 +19,19 @@ namespace SpaceShared.UI
         ** Accessors
         *********/
         public bool Bold { get; set; } = false;
-        public float NonBoldScale { get; set; } = 1f; // Only applies when Bold = false
+        public float NonBoldScale
+        {
+            get => this.Scale;
+            set => this.Scale = value;
+        } // Maintained for compatibility
+
         public bool NonBoldShadow { get; set; } = true; // Only applies when Bold = false
         public Color IdleTextColor { get; set; } = Game1.textColor;
         public Color HoverTextColor { get; set; } = Game1.unselectedOptionColor;
 
         public SpriteFont Font { get; set; } = Game1.dialogueFont; // Only applies when Bold = false
 
-        public float Scale => this.Bold ? 1f : this.NonBoldScale;
+        public float Scale { get; set; } = 1.0f;
 
         public string String { get; set; }
 
@@ -57,7 +62,7 @@ namespace SpaceShared.UI
         /// <summary>Measure the label's rendered dialogue text size.</summary>
         public Vector2 Measure()
         {
-            return Label.MeasureString(this.String, this.Bold, scale: this.Bold ? 1f : this.NonBoldScale, font: this.Font);
+            return Label.MeasureString(this.String, this.Bold, scale: this.Scale, font: this.Font);
         }
 
         /// <inheritdoc />
@@ -68,7 +73,12 @@ namespace SpaceShared.UI
 
             bool altColor = this.Hover && this.Callback != null;
             if (this.Bold)
+            {
+                float originalTextScale = SpriteText.fontPixelZoom;
+                SpriteText.fontPixelZoom *= this.Scale;
                 SpriteText.drawString(b, this.String, (int)this.Position.X, (int)this.Position.Y, layerDepth: 1, color: altColor ? SpriteText.color_Gray : null);
+                SpriteText.fontPixelZoom = originalTextScale;
+            }
             else
             {
                 Color col = altColor ? this.HoverTextColor : this.IdleTextColor;
@@ -76,9 +86,9 @@ namespace SpaceShared.UI
                     return;
 
                 if (this.NonBoldShadow)
-                    Utility.drawTextWithShadow(b, this.String, this.Font, this.Position, col, this.NonBoldScale);
+                    Utility.drawTextWithShadow(b, this.String, this.Font, this.Position, col, this.Scale);
                 else
-                    b.DrawString(this.Font, this.String, this.Position, col, 0f, Vector2.Zero, this.NonBoldScale, SpriteEffects.None, 1);
+                    b.DrawString(this.Font, this.String, this.Position, col, 0f, Vector2.Zero, this.Scale, SpriteEffects.None, 1);
             }
         }
 


### PR DESCRIPTION
Rewriting my configs to have full GMCM support and realized I wanted a "subheader" type of label since I have so many different modules that I wanted to title. 

Didn't enjoy the idea of using a full size title, and a paragraph was too small to look good, so I added my own.
Updated labels so that bold font can be scaled using fontPixelZoom and set the scale to 0.75f.


Multiple titles
![Multiple Titles](https://github.com/user-attachments/assets/b8bdb56a-3317-4dff-b4f3-17c20c0f4d8d)

Paragraphs (too small)
![Using Paragraphs](https://github.com/user-attachments/assets/d3c852bb-fc18-4d03-9d00-aa1f92bff2d7)

New SubHeaders
![Subheaders](https://github.com/user-attachments/assets/26f4ec66-ad19-47f8-b874-0a796d16fa74)
