### PR TITLE
Allow TextureOverride packs to set ChancePerTick of animation playing (SpaceCore)

### DIFF
--- a/SpaceCore/VanillaAssetExpansion/TextureOverridePackData.cs
+++ b/SpaceCore/VanillaAssetExpansion/TextureOverridePackData.cs
@@ -22,6 +22,8 @@ namespace SpaceCore.VanillaAssetExpansion
 
         public Point? SourceSizeOverride { get; set; } = null;
 
+        public double? ChancePerTick { get; set; } = null;
+
         internal Texture2D sourceTex;
         internal TextureAnimation animation;
         internal int currFrame = 0;

--- a/SpaceCore/VanillaAssetExpansion/VanillaAssetExpansion.cs
+++ b/SpaceCore/VanillaAssetExpansion/VanillaAssetExpansion.cs
@@ -350,6 +350,13 @@ namespace SpaceCore.VanillaAssetExpansion
                     if (++texOverride.currFrameTick >= texOverride.animation.Frames[texOverride.currFrame].Duration)
                     {
                         texOverride.currFrameTick = 0;
+
+                        double defaultAnimationChance = 1.0; // could make this a config option, but it may be clearer to always keep it 1.0
+                        if (texOverride.currFrame == 0 && (texOverride.ChancePerTick ?? defaultAnimationChance) <= Game1.random.NextDouble())
+                        {
+                            continue;
+                        }
+
                         if (++texOverride.currFrame >= texOverride.animation.Frames.Length)
                         {
                             texOverride.currFrame = 0;


### PR DESCRIPTION
Allow TextureOverride packs to set ChancePerTick of animation playing (SpaceCore)


https://github.com/user-attachments/assets/fd2a472f-9ec6-4ecb-8ee7-d5b736cd5fe2


https://github.com/user-attachments/assets/751fdb6b-27c9-434d-97e0-e562b14c6ec3

