### PR TITLE
Update ContentPatcherAnimations to support SDV 1.6.1 and Content Patcher 2.5.1

### DIFF
--- a/ContentPatcherAnimations/ContentPatcherAnimations.csproj
+++ b/ContentPatcherAnimations/ContentPatcherAnimations.csproj
@@ -4,8 +4,8 @@
   <Import Project="..\SpaceSharedPatching\SpaceSharedPatching.projitems" Label="Shared" />
 
   <PropertyGroup>
-    <Version>1.2.3</Version>
-    <TargetFramework>net5.0</TargetFramework>
+    <Version>1.2.5</Version>
+    <TargetFramework>net6.0</TargetFramework>
     <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
 

--- a/ContentPatcherAnimations/Framework/AssetDrawTracker.cs
+++ b/ContentPatcherAnimations/Framework/AssetDrawTracker.cs
@@ -74,7 +74,7 @@ namespace ContentPatcherAnimations.Framework
         {
             this.CurrentLanguageSuffix = (code == LocalizedContentManager.LanguageCode.en)
                 ? null
-                : $".{Game1.content.LanguageCodeString(Game1.content.GetCurrentLanguage())}";
+                : $".{LocalizedContentManager.LanguageCodeString(Game1.content.GetCurrentLanguage())}";
         }
     }
 }

--- a/ContentPatcherAnimations/Framework/PatchData.cs
+++ b/ContentPatcherAnimations/Framework/PatchData.cs
@@ -18,9 +18,6 @@ namespace ContentPatcherAnimations.Framework
         /// <summary>Simplifies access to private code.</summary>
         private readonly IReflectionHelper Reflection;
 
-        /// <summary>The underlying patch's <c>LastChangedTick</c> property.</summary>
-        private readonly IReflectedProperty<int> LastChangedTickProperty;
-
         /// <summary>The underlying patch's <c>IsReady</c> property.</summary>
         private readonly IReflectedProperty<bool> IsReadyProperty;
 
@@ -41,9 +38,6 @@ namespace ContentPatcherAnimations.Framework
 
         /// <summary>The raw patch name to display in error messages.</summary>
         private readonly string Name;
-
-        /// <summary>The last <see cref="Game1.ticks"/> value when the underlying patch data was last changed.</summary>
-        private int LastChangedTick;
 
         /// <summary>The cached source frame data.</summary>
         private readonly IDictionary<int, Color[]> AnimationFrames = new Dictionary<int, Color[]>();
@@ -98,7 +92,6 @@ namespace ContentPatcherAnimations.Framework
             this.Name = name;
             this.Reflection = reflection;
 
-            this.LastChangedTickProperty = reflection.GetProperty<int>(patch, "LastChangedTick");
             this.IsReadyProperty = reflection.GetProperty<bool>(patch, "IsReady");
             this.IsAppliedProperty = reflection.GetProperty<bool>(patch, "IsApplied");
             this.FromAssetProperty = reflection.GetProperty<string>(patch, "FromAsset");
@@ -112,14 +105,12 @@ namespace ContentPatcherAnimations.Framework
         /// <summary>Refresh the patch data if the underlying patch changed.</summary>
         public void RefreshIfNeeded()
         {
-            // update IsActive (doesn't change LastChangedTick value)
+            // update IsActive
             this.IsActive = this.IsAppliedProperty.GetValue();
 
             // refresh if patch data changed
-            int lastChangedTick = this.LastChangedTickProperty.GetValue();
-            if (lastChangedTick > this.LastChangedTick || this.ForceNextRefresh)
+            if (this.ForceNextRefresh)
             {
-                this.LastChangedTick = lastChangedTick;
                 this.ForceNextRefresh = false;
                 this.AnimationFrames.Clear();
 


### PR DESCRIPTION
Fixes #485

LocalizedContentManager change required for successful build with .NET 6.0.

LastChangedTick property was removed from Content Patcher with 2.5.1 here: https://github.com/Pathoschild/StardewMods/commit/9f1799d79a26cc7a5c14cd4e32e3e91bf12486c2.

The commit message says "unused field", so CPA's special handling was removed also.

CPA 1.2.4 doesn't seem to be in source control, so its changes might need to be merged first.
