### PR TITLE
Fix get-only fields in content data models

### DIFF
--- a/SpaceCore/Guidebooks/GuidebookData.cs
+++ b/SpaceCore/Guidebooks/GuidebookData.cs
@@ -1,11 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Xna.Framework;
 using StardewValley;
-using StardewValley.Menus;
 
 namespace SpaceCore.Guidebooks;
 public class GuidebookData
@@ -25,7 +20,7 @@ public class GuidebookData
         public int TabIconScale { get; set; } = Game1.pixelZoom;
         public string Condition { get; set; } = "TRUE";
 
-        public List<PageData> Pages { get; }= new();
+        public List<PageData> Pages { get; set; } = new();
     }
 
     public string Title { get; set; }
@@ -33,5 +28,5 @@ public class GuidebookData
     public Vector2 PagePadding { get; set; } = new(28, 28);
     public Vector2 PageSize { get; set; } = new(600, 500); // Only used if PageTexture is null
     public string DefaultChapter { get; set; }
-    public Dictionary<string, ChapterData> Chapters { get; } = new();
+    public Dictionary<string, ChapterData> Chapters { get; set; } = new();
 }

--- a/SpaceCore/VanillaAssetExpansion/Shops.cs
+++ b/SpaceCore/VanillaAssetExpansion/Shops.cs
@@ -1,8 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using HarmonyLib;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -30,7 +27,7 @@ namespace SpaceCore.VanillaAssetExpansion
             public Rectangle IconRect { get; set; }
             public string FilterCondition { get; set; } = "TRUE";
         }
-        public List<CustomTab> CustomTabs { get; } = new List<CustomTab>();
+        public List<CustomTab> CustomTabs { get; set; } = new List<CustomTab>();
     }
 
     [HarmonyPatch(typeof(ShopMenu), nameof(ShopMenu.setUpStoreForContext))]


### PR DESCRIPTION
This commit fixes two issues:
- For the `spacechase0.SpaceCore/Guidebooks` asset, the upcoming Content Patcher 2.7.0 fixes a bug where `EditData` would append values to a list/dictionary field in some cases instead of replacing it. That means the get-only fields like `Chapters` will become empty, since Json.NET can't assign to them.
- For the `spacechase0.SpaceCore/ShopExtensionData` asset, the `CustomTabs` field would always be empty since that was already the default SMAPI behavior.