### PR TITLE
[SpaceCore] Allow exit with held item to avoid a softlock in equipment menu

### DIFF
--- a/SpaceCore/EquipmentMenu.cs
+++ b/SpaceCore/EquipmentMenu.cs
@@ -28,7 +28,8 @@ namespace SpaceCore
             yPositionOnScreen -= 80;
             width += 80;
             height += 80;
-            
+            AllowExitWithHeldItem = true;
+
             int PerRow = 4;
             int amt = SpaceCore.EquipmentSlots.Count;
             int wamt = Math.Min(amt, PerRow);


### PR DESCRIPTION
In current version of spacecore, `EquipmentMenu.AllowExitWithHeldItem` is false and soft locks player on being unable to exit the equipment menu in this scenario:
1. There are dropped items on the ground near the player
2. The player's inventory is full
3. They open the equipment menu and grabbed an item, allowing them to pick up one of the dropped items
4. Player can no longer exit the equipment menu.

This change sets `EquipmentMenu.AllowExitWithHeldItem` to true, which allows player to exit menu with a held item and avoids the soft lock scenario. The held item is either returned to inventory, or dropped via `MenuWithInventory.DropHeldItem`.