### PR TITLE
add more delete comments for IGenericModConfigMenuApi.cs

### DIFF
--- a/GenericModConfigMenu/IGenericModConfigMenuApi.cs
+++ b/GenericModConfigMenu/IGenericModConfigMenuApi.cs
@@ -1,5 +1,5 @@
 using System;
-using GenericModConfigMenu.Framework;
+using GenericModConfigMenu.Framework; // DELETE THIS LINE WHEN COPIED INTO YOUR MOD CODE
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;


### PR DESCRIPTION
I noticed when making a custom ModConfig and importing this code, we should also remove the UsingGenericModConfigMenu.Framework code (since that is not actually imported in our source code)