### PR TITLE
Add null ToolData check in ToolDataDefinitionPatcher

### DIFF
--- a/SpaceCore/Patches/ToolDataDefinitionPatcher.cs
+++ b/SpaceCore/Patches/ToolDataDefinitionPatcher.cs
@@ -42,6 +42,10 @@ namespace SpaceCore.Patches
             if (tool is not ErrorTool)
                 return tool;
 
+            // no tool data (i.e. GenericTool)
+            if (toolData is null)
+                return tool;
+
             // try to find a registered type matching provided type name
             Type type = SpaceCore.ModTypes.Where(t => t.AssemblyQualifiedName == toolData.ClassName).FirstOrDefault();
 


### PR DESCRIPTION
In the current version of Stardew at the time of writing this (1.6.15), trying to create an invalid tool in some cases will lead to a NullReferenceException due to its ToolData not existing (e.g. a `GenericTool` instance). This will be fixed in 1.6.16. However, 1.6.16 has no release date, currently this NRE happens in SpaceCore instead (inside `ToolDataDefinitionPatcher.After_CreateToolInstance`), and it's unknown how exactly it will be fixed in the base game in the future (the null check may be added after `CreateToolInstance`, in which case SpaceCore will still throw an NRE).

All this PR does is return the tool if `ToolData` is null, just like it would if it were an `ErrorTool` instance, preventing an NRE from the rest of the function trying to access null ToolData.