### PR TITLE
[SpaceCore] Respect isForcedScytheHarvest for crop extension

### DIFF
--- a/framework/SpaceCore/VanillaAssetExpansion/Crops.cs
+++ b/framework/SpaceCore/VanillaAssetExpansion/Crops.cs
@@ -35,7 +35,7 @@ namespace SpaceCore.VanillaAssetExpansion
     [HarmonyPatch(typeof(Crop), nameof(Crop.harvest))]
     public static class CropHarvestOverridePatch
     {
-        public static bool Prefix(Crop __instance, int xTile, int yTile, HoeDirt soil, JunimoHarvester junimoHarvester, ref bool __result)
+        public static bool Prefix(Crop __instance, int xTile, int yTile, HoeDirt soil, JunimoHarvester junimoHarvester, bool isForcedScytheHarvest, ref bool __result)
         {
             var dict = Game1.content.Load<Dictionary<string, CropExtensionData>>("spacechase0.SpaceCore/CropExtensionData");
             if (__instance.netSeedIndex.Value == null || !dict.TryGetValue(__instance.netSeedIndex.Value, out var extData))
@@ -59,7 +59,7 @@ namespace SpaceCore.VanillaAssetExpansion
             void DoStuff( Item harvestedItem, int numToHarvest, ref bool localSuccess )
             {
                 HarvestMethod harvestMethod = data?.HarvestMethod ?? HarvestMethod.Grab;
-                if (harvestMethod == HarvestMethod.Scythe)
+                if (harvestMethod == HarvestMethod.Scythe || isForcedScytheHarvest)
                 {
                     if (junimoHarvester != null)
                     {


### PR DESCRIPTION
Currently the iridium scythe is forced into player harvest animation when harvesting any crop with additional harvests via spacecore which is very annoying. Fix this by checking the isForcedScytheHarvest arg.