### PR TITLE
[SpaceCore] Feature: Draw behaviours for custom buff effects

### DIFF
--- a/SpaceCore/Patches/SkillBuffPatcher.cs
+++ b/SpaceCore/Patches/SkillBuffPatcher.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Emit;
 using System.Text;
 using HarmonyLib; // el diavolo nuevo
@@ -119,49 +120,108 @@ internal class SkillBuffPatcher : BasePatcher
         }
     }
 
-    private static IEnumerable<CodeInstruction> Transpile_IClickableMenu_DrawHoverText(IEnumerable<CodeInstruction> instructions)
+    private static IEnumerable<CodeInstruction> Transpile_IClickableMenu_DrawHoverText(ILGenerator gen, MethodBase original, IEnumerable<CodeInstruction> il)
     {
-        List<CodeInstruction> codeInstructions = new List<CodeInstruction>(instructions);
-        int step = 0;
-        yield return codeInstructions[0];
-        for (int i = 1; i < codeInstructions.Count; i++)
+        var matcher = new CodeMatcher(il);
+
+        matcher.Start();
+
+        // Add to HoverText TextureBox height:
+
+        // MATCH: if (buffIconsToDisplay != null)
+        matcher.MatchEndForward(
+            new(OpCodes.Ldarg_S, (byte)8),
+            new(OpCodes.Brfalse_S));
+
+        // INSERT: height += SkillBuffPatcher.GetHeightAdjustment(buffIconsToDisplay, hoveredItem, height)
+        matcher.InsertAndAdvance(
+            new(OpCodes.Ldarg_S, 8),
+            new(OpCodes.Ldarg_S, 9),
+            new(OpCodes.Ldloc_2),
+            CodeInstruction.Call(typeof(SkillBuffPatcher), nameof(SkillBuffPatcher.GetHeightAdjustment)),
+            new(OpCodes.Stloc_2));
+
+        // Check to set HoverText TextureBox minimum width:
+
+        // MATCH: if (buffIconsToDisplay != null)
+        matcher.MatchEndForward(
+            new(OpCodes.Ldarg_S, (byte)8),
+            new(OpCodes.Brfalse_S));
+
+        // INSERT: width = SkillBuffPatcher.GetWidthAdjustment(font, hoveredItem, width)
+        matcher.InsertAndAdvance(
+            new(OpCodes.Ldarg_S, 2),
+            new(OpCodes.Ldarg_S, 9),
+            new(OpCodes.Ldloc_1),
+            CodeInstruction.Call(typeof(SkillBuffPatcher), nameof(GetWidthAdjustment)),
+            new(OpCodes.Stloc_1));
+
+        // Draw SkillBuff custom skill buff effects:
+
+        // above the divider (health + stamina):
+
+        // these are attributes more closely tied to health/stamina than
+        // skills and combat attributes, so they're drawn separately
+
+        // MATCH: if (buffIconsToDisplay != null)
+        matcher.MatchEndForward(
+            new(OpCodes.Ldarg_S, (byte)8),
+            new(OpCodes.Brfalse)); // not _s
+
+        // INSERT: y += SkillBuffPatcher.DrawAdditionalBuffEffects(b, font, hoveredItem, x, y)
+        matcher.InsertAndAdvance(
+            new(OpCodes.Ldarg_S, 0),
+            new(OpCodes.Ldarg_S, 2),
+            new(OpCodes.Ldarg_S, 9),
+            new(OpCodes.Ldloc, 5),
+            new(OpCodes.Ldloc, 6),
+            CodeInstruction.Call(typeof(SkillBuffPatcher), nameof(DrawAdditionalBuffEffects)),
+            new(OpCodes.Stloc, 6));
+
+        // optional divider ( | skills + attributes):
+
+        // given the base game divider draw behaviour requires you to have included some
+        // basic buff attributes, items with only SpaceCore custom skill buff effects
+        // need to manually draw the divider and their buff effects outside of the usual branch
+
+        // INSERT: y += SkillBuffPatcher.DrawCustomSkillBuffEffectsIfNoBasicEffects(b, font, hoveredItem, x, y, width, buffIconsToDisplay, craftingIngredients)
+        matcher.InsertAndAdvance(
+            new(OpCodes.Ldarg_S, 0),
+            new(OpCodes.Ldarg_S, 2),
+            new(OpCodes.Ldarg_S, 9),
+            new(OpCodes.Ldloc, 5),
+            new(OpCodes.Ldloc, 6),
+            new(OpCodes.Ldloc, 1),
+            new(OpCodes.Ldarg_S, 8),
+            new(OpCodes.Ldarg_S, 16),
+            CodeInstruction.Call(typeof(SkillBuffPatcher), nameof(DrawCustomSkillBuffEffectsIfNoBasicEffects)),
+            new(OpCodes.Stloc, 6));
+
+        // below the divider (skills + attributes):
+
+        // these are drawn above basic skills, as it might look odd having them
+        // below basic non-skill attributes, such as attack, defence, magnetism, ...
+
+        // MATCH: b.Draw(Game1.staminaRect, new Rectangle(...), new Color(...));
+        matcher.MatchEndForward(new CodeMatch(op => op.Is(OpCodes.Callvirt, AccessTools.Method(typeof(SpriteBatch), nameof(SpriteBatch.Draw), [typeof(Texture2D), typeof(Rectangle), typeof(Color)]))));
+
+        // INSERT: y += SkillBuffPatcher.DrawCustomSkillBuffEffects(b, font, hoveredItem, x, y)
+        matcher.InsertAndAdvance(
+            new(OpCodes.Ldarg_S, 0),
+            new(OpCodes.Ldarg_S, 2),
+            new(OpCodes.Ldarg_S, 9),
+            new(OpCodes.Ldloc, 5),
+            new(OpCodes.Ldloc, 6),
+            CodeInstruction.Call(typeof(SkillBuffPatcher), nameof(DrawCustomSkillBuffEffects)),
+            new(OpCodes.Stloc, 6));
+
+        if (matcher.IsInvalid)
         {
-            if (!codeInstructions[i - 1].Is(OpCodes.Ldarg_S, 8) || (!(codeInstructions[i].opcode == OpCodes.Brfalse_S) && !(codeInstructions[i].opcode == OpCodes.Brfalse)))
-            {
-                yield return codeInstructions[i];
-                continue;
-            }
-
-            if (step == 0)
-            {
-                yield return new CodeInstruction(OpCodes.Ldarg_S, 8);
-                yield return new CodeInstruction(OpCodes.Ldarg_S, 9);
-                yield return new CodeInstruction(OpCodes.Ldloc_2);
-                yield return CodeInstruction.Call(typeof(SkillBuffPatcher), nameof(GetHeightAdjustment));
-                yield return new CodeInstruction(OpCodes.Stloc_2);
-            }
-            else if (step == 1)
-            {
-                yield return new CodeInstruction(OpCodes.Ldarg_S, 2);
-                yield return new CodeInstruction(OpCodes.Ldarg_S, 9);
-                yield return new CodeInstruction(OpCodes.Ldloc_1);
-                yield return CodeInstruction.Call(typeof(SkillBuffPatcher), nameof(GetWidthAdjustment));
-                yield return new CodeInstruction(OpCodes.Stloc_1);
-            }
-            else if (step == 2)
-            {
-                yield return new CodeInstruction(OpCodes.Ldarg_S, 0);
-                yield return new CodeInstruction(OpCodes.Ldarg_S, 2);
-                yield return new CodeInstruction(OpCodes.Ldarg_S, 9);
-                yield return new CodeInstruction(OpCodes.Ldloc, 5);
-                yield return new CodeInstruction(OpCodes.Ldloc, 6);
-                yield return CodeInstruction.Call(typeof(SkillBuffPatcher), nameof(DrawCustomSkillBuff));
-                yield return new CodeInstruction(OpCodes.Stloc, 6);
-            }
-
-            yield return codeInstructions[i];
-            step++;
+            Log.Error($"Failed to apply {nameof(SkillBuffPatcher)} {nameof(Transpile_IClickableMenu_DrawHoverText)}. Custom buff effects will not be listed on items.");
+            return il;
         }
+
+        return matcher.InstructionEnumeration();
     }
 
     private static int GetHeightAdjustment(string[] buffIconsToDisplay, Item hoveredItem, int height)
@@ -186,7 +246,7 @@ internal class SkillBuffPatcher : BasePatcher
                     if (skill is null)
                         continue;
 
-                    height += 34;
+                    height += 34 + 5;
                 }
                 if (health != 0)
                 {
@@ -243,7 +303,10 @@ internal class SkillBuffPatcher : BasePatcher
         return width;
     }
 
-    private static int DrawCustomSkillBuff(SpriteBatch b, SpriteFont font, Item hoveredItem, int x, int y)
+    /// <summary>
+    /// For items with basic buff attributes, draws custom skill buff effects, or does nothing if no custom skill effects are found.
+    /// </summary>
+    private static int DrawCustomSkillBuffEffects(SpriteBatch b, SpriteFont font, Item hoveredItem, int x, int y)
     {
         if (hoveredItem is null ||
             !Game1.objectData.TryGetValue(hoveredItem.ItemId, out ObjectData data) ||
@@ -253,8 +316,8 @@ internal class SkillBuffPatcher : BasePatcher
             return y;
         }
 
-        Vector2 offset = new Vector2(4 + 1, 4) * Game1.pixelZoom;
-        Point spacing = new Point(34, 34);
+        Vector2 offset = new Vector2(16 + 4, 16);
+        Point spacing = new Point(34, 34 + 5);
 
         foreach (var buffData in data.Buffs)
         {
@@ -269,19 +332,74 @@ internal class SkillBuffPatcher : BasePatcher
                     SkillBuff.DrawBuffEffect(b, new Vector2(x, y) + offset, entry.Value, skill.GetName(), font: font, icon: skill.SkillsPageIcon, spacing: spacing.X);
                     y += spacing.Y;
                 }
-                if (health != 0)
-                {
-                    SkillBuff.DrawHealthRegenBuffEffect(b, new Vector2(x, y) + offset, health, font: font, spacing: spacing.X);
-                    y += spacing.Y;
-                }
+            }
+        }
+
+        return y;
+    }
+
+    /// <summary>
+    /// For all items, draws any SpaceCore additional buff effects, or does nothing if no additional effects are found.
+    /// </summary>
+    private static int DrawAdditionalBuffEffects(SpriteBatch b, SpriteFont font, Item hoveredItem, int x, int y)
+    {
+        if (hoveredItem is null ||
+            !Game1.objectData.TryGetValue(hoveredItem.ItemId, out ObjectData data) ||
+            data.Buffs is null ||
+            data.Buffs.All(b => b.CustomFields is null || b.CustomFields.Count == 0))
+        {
+            return y;
+        }
+
+        Vector2 offset = new Vector2(16 + 4, 16);
+        Point spacing = new Point(34, 34);
+
+        foreach (var buffData in data.Buffs)
+        {
+            if (SkillBuff.TryGetAdditionalBuffEffects(buffData.CustomFields, out var skills, out float health, out float stamina))
+            {
                 if (stamina != 0)
                 {
                     SkillBuff.DrawStaminaRegenBuffEffect(b, new Vector2(x, y) + offset, stamina, font: font, spacing: spacing.X);
                     y += spacing.Y;
                 }
+                if (health != 0)
+                {
+                    SkillBuff.DrawHealthRegenBuffEffect(b, new Vector2(x, y) + offset, health, font: font, spacing: spacing.X);
+                    y += spacing.Y;
+                }
             }
         }
 
+        return y;
+    }
+
+    /// <summary>
+    /// For hovered items without basic buff attributes, draws a divider and custom skill buff effects, or does nothing if no custom skill effects are found..
+    /// </summary>
+    private static int DrawCustomSkillBuffEffectsIfNoBasicEffects(SpriteBatch b, SpriteFont font, Item hoveredItem, int x, int y, int width, string[] buffIconsToDisplay, CraftingRecipe craftingIngredients)
+    {
+        // duplicate spacecore code
+        if (hoveredItem is null ||
+            !Game1.objectData.TryGetValue(hoveredItem.ItemId, out ObjectData data) ||
+            data.Buffs is null ||
+            data.Buffs.All(b => b.CustomFields is null || b.CustomFields.Count == 0))
+        {
+            return y;
+        }
+
+        // handle alternate branch in base game code without transpiling labels
+        if (buffIconsToDisplay is null)
+        {
+            // duplicate base game code
+            y += 16;
+            b.Draw(Game1.staminaRect, new Rectangle(x + 12, y + 6, width - ((craftingIngredients is not null) ? 4 : 24), 2), new Color(207, 147, 103) * 0.8f);
+
+            // duplicate spacecore code
+            y += SkillBuffPatcher.DrawCustomSkillBuffEffects(b, font, hoveredItem, x, y);
+        }
+
+        // this is a miserable method
         return y;
     }
 }

--- a/SpaceCore/Patches/SkillBuffPatcher.cs
+++ b/SpaceCore/Patches/SkillBuffPatcher.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
 using System.Text;
-using HarmonyLib;
+using HarmonyLib; // el diavolo nuevo
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Spacechase.Shared.Patching;
@@ -12,7 +12,6 @@ using StardewModdingAPI;
 using StardewValley;
 using StardewValley.GameData.Objects;
 using StardewValley.Menus;
-using static System.Net.Mime.MediaTypeNames;
 using static SpaceCore.Skills;
 
 namespace SpaceCore.Patches;
@@ -51,10 +50,7 @@ internal class SkillBuffPatcher : BasePatcher
         // If there is custom data, find the matching buff to wrap.
         foreach ( var buffData in data.Buffs )
         {
-            if (buffData.CustomFields?.Any(b => b.Key.StartsWith("spacechase.SpaceCore.SkillBuff.") ||
-                                                b.Key.StartsWith("spacechase0.SpaceCore.SkillBuff.") ||
-                                                b.Key.StartsWith("spacechase0.SpaceCore/HealthRegeneration") ||
-                                                b.Key.StartsWith("spacechase0.SpaceCore/StaminaRegeneration") ) ?? false)
+            if (SkillBuff.TryGetAdditionalBuffEffects(buffData.CustomFields, out var skills, out float health, out float stamina))
             {
                 Buff matchingBuff = null;
                 string id = buffData.BuffId;
@@ -113,13 +109,10 @@ internal class SkillBuffPatcher : BasePatcher
                 continue;
             }
 
-            StringBuilder sb = new StringBuilder();
-            sb.Append("+");
-            sb.Append(skillLevel.Value);
-            sb.Append(" ");
-            sb.Append(skill.GetName());
-            sb.Append("\n");
-            sb.Append(Game1.content.LoadString("Strings\\StringsFromCSFiles:Buff.cs.508"));
+            StringBuilder sb = new();
+            sb.Append(SkillBuff.FormattedBuffEffect(skillLevel.Value, skillLevel.Key));
+            sb.AppendLine();
+            sb.Append(Game1.content.LoadString("Strings/StringsFromCSFiles:Buff.cs.508"));
             sb.Append(buff.displaySource ?? buff.source);
 
             yield return new ClickableTextureComponent("", Rectangle.Empty, null, sb.ToString(), skill.Icon, new Rectangle(0, 0, 16, 16), 4f);
@@ -184,22 +177,25 @@ internal class SkillBuffPatcher : BasePatcher
         bool addedAny = false;
         foreach (var buffData in data.Buffs)
         {
-            if (buffData.CustomFields is null)
-                continue;
-            foreach (var entry in Skills.SkillBuff.ParseCustomFields(buffData.CustomFields))
+            if (SkillBuff.TryGetAdditionalBuffEffects(buffData.CustomFields, out var skills, out float health, out float stamina))
             {
                 addedAny = true;
-                height += 34;
-            }
-            if (buffData.CustomFields.ContainsKey("spacechase0.SpaceCore/HealthRegeneration"))
-            {
-                addedAny = true;
-                height += 34;
-            }
-            if (buffData.CustomFields.ContainsKey("spacechase0.SpaceCore/StaminaRegeneration"))
-            {
-                addedAny = true;
-                height += 34;
+                foreach (var entry in skills)
+                {
+                    Skills.Skill skill = Skills.GetSkill(entry.Key);
+                    if (skill is null)
+                        continue;
+
+                    height += 34;
+                }
+                if (health != 0)
+                {
+                    height += 34;
+                }
+                if (stamina != 0)
+                {
+                    height += 34;
+                }
             }
         }
 
@@ -221,29 +217,26 @@ internal class SkillBuffPatcher : BasePatcher
             return width;
         }
 
-        foreach ( var buffData in data.Buffs )
+        foreach (var buffData in data.Buffs)
         {
-            if (buffData.CustomFields is null)
-                continue;
-            foreach (var entry in Skills.SkillBuff.ParseCustomFields(buffData.CustomFields))
+            if (SkillBuff.TryGetAdditionalBuffEffects(buffData.CustomFields, out var skills, out float health, out float stamina))
             {
-                Skills.Skill skill = Skills.GetSkill(entry.Key);
-
-                if (skill is null)
+                foreach (var entry in skills)
                 {
-                    continue;
+                    Skills.Skill skill = Skills.GetSkill(entry.Key);
+                    if (skill is null)
+                        continue;
+
+                    width = Math.Max(width, (int)font.MeasureString("+99 " + skill.GetName()).X) + 92;
                 }
-
-                width = Math.Max(width, (int)font.MeasureString("+99 " + skill.GetName()).X) + 92;
-            }
-
-            if (buffData.CustomFields.ContainsKey("spacechase0.SpaceCore/HealthRegeneration"))
-            {
-                width = Math.Max(width, (int)font.MeasureString("+999 " + I18n.HealthRegen()).X) + 92;
-            }
-            if (buffData.CustomFields.ContainsKey("spacechase0.SpaceCore/StaminaRegeneration"))
-            {
-                width = Math.Max(width, (int)font.MeasureString("+999 " + I18n.StaminaRegen()).X) + 92;
+                if (health != 0)
+                {
+                    width = Math.Max(width, (int)font.MeasureString("+999 " + I18n.HealthRegen()).X) + 92;
+                }
+                if (stamina != 0)
+                {
+                    width = Math.Max(width, (int)font.MeasureString("+999 " + I18n.StaminaRegen()).X) + 92;
+                }
             }
         }
 
@@ -260,40 +253,32 @@ internal class SkillBuffPatcher : BasePatcher
             return y;
         }
 
+        Vector2 offset = new Vector2(4 + 1, 4) * Game1.pixelZoom;
+        Point spacing = new Point(34, 34);
+
         foreach (var buffData in data.Buffs)
         {
-            if (buffData.CustomFields is null)
-                continue;
-            foreach (var entry in Skills.SkillBuff.ParseCustomFields(buffData.CustomFields))
+            if (SkillBuff.TryGetAdditionalBuffEffects(buffData.CustomFields, out var skills, out float health, out float stamina))
             {
-                Skills.Skill skill = Skills.GetSkill(entry.Key);
-
-                if (skill is null)
+                foreach (var entry in skills)
                 {
-                    continue;
+                    Skills.Skill skill = Skills.GetSkill(entry.Key);
+                    if (skill is null)
+                        continue;
+
+                    SkillBuff.DrawBuffEffect(b, new Vector2(x, y) + offset, entry.Value, skill.GetName(), font: font, icon: skill.SkillsPageIcon, spacing: spacing.X);
+                    y += spacing.Y;
                 }
-                string text = $"+{entry.Value}  {skill.GetName()}";
-
-                Utility.drawWithShadow(b, skill.SkillsPageIcon, new Vector2(x + 16 + 4, y + 16), new Rectangle(0, 0, 10, 10), Color.White, 0f, Vector2.Zero, 3f, flipped: false, 0.95f);
-                Utility.drawTextWithShadow(b, text, font, new Vector2(x + 16 + 34 + 4, y + 16), Game1.textColor);
-                y += 34;
-            }
-
-            if (buffData.CustomFields.ContainsKey("spacechase0.SpaceCore/HealthRegeneration"))
-            {
-                float amt = float.Parse(buffData.CustomFields["spacechase0.SpaceCore/HealthRegeneration"]);
-                string text = (amt >= 0 ? "+" : "") + amt + " " + I18n.HealthRegen();
-                Utility.drawWithShadow(b, Game1.mouseCursors, new Vector2(x + 16 + 4, y + 16), new Rectangle(0, 438, 10, 10), Color.White, 0f, Vector2.Zero, 3f, flipped: false, 0.95f);
-                Utility.drawTextWithShadow(b, text, font, new Vector2(x + 16 + 34 + 4, y + 16), Game1.textColor);
-                y += 34;
-            }
-            if (buffData.CustomFields.ContainsKey("spacechase0.SpaceCore/StaminaRegeneration"))
-            {
-                float amt = float.Parse(buffData.CustomFields["spacechase0.SpaceCore/StaminaRegeneration"]);
-                string text = (amt >= 0 ? "+" : "") + amt + " " + I18n.StaminaRegen();
-                Utility.drawWithShadow(b, Game1.mouseCursors, new Vector2(x + 16 + 4, y + 16), new Rectangle((amt < 0) ? 140 : 0, 428, 10, 10), Color.White, 0f, Vector2.Zero, 3f, flipped: false, 0.95f);
-                Utility.drawTextWithShadow(b, text, font, new Vector2(x + 16 + 34 + 4, y + 16), Game1.textColor);
-                y += 34;
+                if (health != 0)
+                {
+                    SkillBuff.DrawHealthRegenBuffEffect(b, new Vector2(x, y) + offset, health, font: font, spacing: spacing.X);
+                    y += spacing.Y;
+                }
+                if (stamina != 0)
+                {
+                    SkillBuff.DrawStaminaRegenBuffEffect(b, new Vector2(x, y) + offset, stamina, font: font, spacing: spacing.X);
+                    y += spacing.Y;
+                }
             }
         }
 

--- a/SpaceCore/Skills.cs
+++ b/SpaceCore/Skills.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Newtonsoft.Json;
@@ -117,20 +118,33 @@ namespace SpaceCore
 
             public SkillBuff(Buff buff, string id, Dictionary<string, string> customFields) : base(id, buff.source, buff.displaySource, buff.millisecondsDuration, buff.iconTexture, buff.iconSheetIndex, buff.effects, false, buff.displayName, buff.description)
             {
-                foreach (var entry in ParseCustomFields(customFields))
+                if (SkillBuff.TryGetAdditionalBuffEffects(customFields, out var skills, out float health, out float stamina))
                 {
-                    SkillLevelIncreases[entry.Key] = entry.Value;
+                    foreach (var entry in skills)
+                        this.SkillLevelIncreases[entry.Key] = entry.Value;
+                    this.HealthRegen = health;
+                    this.StaminaRegen = stamina;
                 }
-                if (customFields.TryGetValue(RegenHealth, out string regenStr) && float.TryParse(regenStr, out float regen))
-                    HealthRegen = regen;
-                if (customFields.TryGetValue(RegenStamina, out regenStr) && float.TryParse(regenStr, out regen))
-                    StaminaRegen = regen;
-
             }
 
-            public static IEnumerable<KeyValuePair<string, int>> ParseCustomFields(Dictionary<string, string> customFields)
+            /// <summary>
+            /// Parses a given dictionary, probably a <c>CustomFields</c> field, for any SpaceCore additional buff effects.
+            /// </summary>
+            /// <param name="dict"></param>
+            /// <param name="skills">Map of SpaceCore <see cref="Skill"/> IDs to their respective values, or an empty dictionary if none are found.</param>
+            /// <param name="health">Float value of health regenerated per second.</param>
+            /// <param name="stamina">Float value of energy regenerated per second.</param>
+            /// <returns>Returns whether any additional buff effects were found with tangible (non-zero or non-empty) values.</returns>
+            public static bool TryGetAdditionalBuffEffects(Dictionary<string, string> dict, out Dictionary<string, int> skills, out float health, out float stamina)
             {
-                foreach (KeyValuePair<string, string> entry in customFields)
+                skills = [];
+                health = 0;
+                stamina = 0;
+
+                if (dict is null || !dict.Any())
+                    return false;
+
+                foreach (var entry in dict)
                 {
                     if (!entry.Key.StartsWith(SkillBuffField) && !entry.Key.StartsWith(SkillBuffFieldLegacy))
                     {
@@ -144,22 +158,94 @@ namespace SpaceCore
                         continue;
                     }
 
-                    yield return KeyValuePair.Create(skillId, level);
+                    skills.Add(skillId, level);
                 }
+
+                if (dict.TryGetValue(RegenHealth, out string regenStr) && float.TryParse(regenStr, out float regen))
+                    health = regen;
+                if (dict.TryGetValue(RegenStamina, out regenStr) && float.TryParse(regenStr, out regen))
+                    stamina = regen;
+
+                return skills.Any() || health != 0 || stamina != 0;
             }
 
             public string DescriptionHook()
             {
-                string ret = "";
+                StringBuilder sb = new();
                 if (HealthRegen != 0)
                 {
-                    ret += (HealthRegen > 0 ? "+" : "") + HealthRegen + " " + I18n.HealthRegen();
+                    sb.Append(FormattedBuffEffect(HealthRegen, I18n.HealthRegen()));
                 }
                 if (StaminaRegen != 0)
                 {
-                    ret += (StaminaRegen > 0 ? "+" : "") + StaminaRegen + " " + I18n.StaminaRegen();
+                    sb.Append(FormattedBuffEffect(StaminaRegen, I18n.StaminaRegen()));
                 }
-                return ret;
+                return sb.ToString();
+            }
+
+            /// <summary>
+            /// Formats a buff effect value into a signed label.
+            /// </summary>
+            /// <param name="value">Buff effect value.</param>
+            /// <param name="label">Translated label.</param>
+            public static string FormattedBuffEffect(float value, string label = null)
+            {
+                return string.IsNullOrWhiteSpace(label) ? $"{(value > 0 ? "+" : "")}{value}" : $"{(value > 0 ? "+" : "")}{value} {label}";
+            }
+
+            /// <summary>
+            /// Draws a buff icon and formatted buff effect value label.
+            /// </summary>
+            /// <param name="position">Local display pixel draw position.</param>
+            /// <param name="value">Buff effect value.</param>
+            /// <param name="label">Translated label. Will be formatted into a standardised style when drawn.</param>
+            /// <param name="font">Font used to draw label. Defaults to <see cref="Game1.smallFont"/>.</param>
+            /// <param name="icon">Texture used for buff icon.</param>
+            /// <param name="iconSource">Area in icon texture used for buff icon when drawn. Defaults to entire texture.</param>
+            /// <param name="alpha">Opacity of icon and label when drawn.</param>
+            /// <param name="spacing">Display pixel spacing between icon and text.</param>
+            /// <param name="shadowAlpha">Relative opacity of shadow when drawn.</param>
+            public static void DrawBuffEffect(SpriteBatch b, Vector2 position, float value, string label = null, SpriteFont font = null, Texture2D icon = null, Rectangle? iconSource = null, float alpha = 1, int spacing = 8 * Game1.pixelZoom, float shadowAlpha = 1)
+            {
+                string text = SkillBuff.FormattedBuffEffect(value, label);
+                int xOffset = 0;
+
+                if (icon is not null)
+                {
+                    Utility.drawWithShadow(b, icon, position, iconSource ?? icon.Bounds, Color.White * alpha, 0f, Vector2.Zero, 3f, flipped: false, layerDepth: 0.95f, shadowIntensity: 0.35f * shadowAlpha * alpha);
+                    xOffset += spacing;
+                }
+                Utility.drawTextWithShadow(b, text, font ?? Game1.smallFont, position + new Vector2(xOffset, 0), Game1.textColor * alpha);
+            }
+
+            /// <summary>
+            /// Draws a buff icon and formatted buff effect value label in the style of a SpaceCore <see cref="HealthRegen"/> buff.
+            /// </summary>
+            /// <param name="position">Local display pixel draw position.</param>
+            /// <param name="value">Health regeneration value.</param>
+            /// <param name="drawText">Whether to draw label in addition to buff effect value.</param>
+            /// <param name="font">Font used to draw label. Defaults to <see cref="Game1.smallFont"/>.</param>
+            /// <param name="alpha">Opacity of icon and label when drawn.</param>
+            /// <param name="spacing">Display pixel spacing between icon and text.</param>
+            /// <param name="shadowAlpha">Relative opacity of shadow when drawn.</param>
+            public static void DrawHealthRegenBuffEffect(SpriteBatch b, Vector2 position, float value, bool drawText = true, SpriteFont font = null, float alpha = 1, int spacing = 8 * Game1.pixelZoom, float shadowAlpha = 1)
+            {
+                SkillBuff.DrawBuffEffect(b, position, value, drawText ? I18n.HealthRegen() : null, font, Game1.mouseCursors, new Rectangle(0, 438, 10, 10), alpha: alpha, spacing: spacing, shadowAlpha: shadowAlpha);
+            }
+
+            /// <summary>
+            /// Draws a buff icon and formatted buff effect value label in the style of a SpaceCore <see cref="StaminaRegen"/> buff.
+            /// </summary>
+            /// <param name="position">Local display pixel draw position.</param>
+            /// <param name="value">Stamina regeneration value.</param>
+            /// <param name="drawText">Whether to draw label in addition to buff effect value.</param>
+            /// <param name="font">Font used to draw label. Defaults to <see cref="Game1.smallFont"/>.</param>
+            /// <param name="alpha">Opacity of icon and label when drawn.</param>
+            /// <param name="spacing">Display pixel spacing between icon and text.</param>
+            /// <param name="shadowAlpha">Relative opacity of shadow when drawn.</param>
+            public static void DrawStaminaRegenBuffEffect(SpriteBatch b, Vector2 position, float value, bool drawText = true, SpriteFont font = null, float alpha = 1, int spacing = 8 * Game1.pixelZoom, float shadowAlpha = 1)
+            {
+                SkillBuff.DrawBuffEffect(b, position, value, drawText ? I18n.StaminaRegen() : null, font, Game1.mouseCursors, new Rectangle((value < 0) ? 140 : 0, 428, 10, 10), alpha: alpha, spacing: spacing, shadowAlpha: shadowAlpha);
             }
 
             public override void OnAdded()

--- a/SpaceCore/VanillaAssetExpansion/Buffs.cs
+++ b/SpaceCore/VanillaAssetExpansion/Buffs.cs
@@ -1,11 +1,8 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using HarmonyLib;
 using StardewValley;
 using StardewValley.Menus;
+using static SpaceCore.Skills;
 
 namespace SpaceCore.VanillaAssetExpansion
 {
@@ -20,13 +17,7 @@ namespace SpaceCore.VanillaAssetExpansion
             if (__instance is Skills.SkillBuff)
                 return;
 
-            if (__instance.customFields == null)
-                return;
-
-            if (__instance.customFields.Any(b => b.Key.StartsWith("spacechase.SpaceCore.SkillBuff.") ||
-                                                 b.Key.StartsWith("spacechase0.SpaceCore.SkillBuff.") ||
-                                                 b.Key.StartsWith("spacechase0.SpaceCore/HealthRegeneration") ||
-                                                 b.Key.StartsWith("spacechase0.SpaceCore/StaminaRegeneration")))
+            if (SkillBuff.TryGetAdditionalBuffEffects(__instance.customFields, out var _, out float _, out float _))
             {
                 Game1.player.applyBuff(new Skills.SkillBuff(__instance, __instance.id, __instance.customFields));
             }
@@ -77,22 +68,13 @@ namespace SpaceCore.VanillaAssetExpansion
 
             if (!DataLoader.Buffs(Game1.content).TryGetValue(buff.id, out var buffData))
                 return;
-            if (buffData.CustomFields == null)
-                return;
 
-            if (buffData.CustomFields.TryGetValue("spacechase0.SpaceCore/HealthRegeneration", out string valStr))
+            if (SkillBuff.TryGetAdditionalBuffEffects(buffData.CustomFields, out var _, out float health, out float stamina))
             {
-                if (float.TryParse(valStr, out float val))
-                {
-                    buff.description += (val >= 0 ? "+" : "") + val + " " + I18n.HealthRegen();
-                }
-            }
-            if (buffData.CustomFields.TryGetValue("spacechase0.SpaceCore/StaminaRegeneration", out valStr))
-            {
-                if (float.TryParse(valStr, out float val))
-                {
-                    buff.description += (val >= 0 ? "+" : "") + val + " " + I18n.StaminaRegen();
-                }
+                if (health != 0)
+                    buff.description += SkillBuff.FormattedBuffEffect(health, I18n.HealthRegen());
+                if (stamina != 0)
+                    buff.description += SkillBuff.FormattedBuffEffect(stamina, I18n.StaminaRegen());
             }
         }
 


### PR DESCRIPTION
### Summary
Rewrites some methods on SpaceCore to better allow for arbitrary draw calls from other mods (read: love of cooking), and fixes some minor presentation issues relating to custom buff effects since SDV1.6.
### Changes
- Separate various `SkillBuff` behaviours into their individual steps, made accessible to other programs.
- Replace `ParseCustomFields` method with new `TryGetAdditionalBuffEffects` method, return success and all parsed buff custom skill buff effects and attributes from parsed `CustomFields` dictionaries.
- Replace `Transpile_IClickableMenu_DrawHoverText` method contents with `CodeMatcher` solution for added precision since SDV1.6 changes to hover text draw behaviours.
### Fixes
- Fix irregular spacing between basic and custom skill buff effect entries and their icons.
- Fix custom skill buff effects placed above divider between health/stamina and buff attributes.