### PR TITLE
[SpaceCore] Bugfix: Statue of Uncertainty taking 20,000g instead of the vanilla 10,000g for modded skills

### DIFF
--- a/SpaceCore/Patches/GameLocationPatcher.cs
+++ b/SpaceCore/Patches/GameLocationPatcher.cs
@@ -161,7 +161,6 @@ namespace SpaceCore.Patches
 
                 Game1.player.Money = Math.Max(0, Game1.player.Money - 10000);
 
-                Game1.player.Money = Math.Max(0, Game1.player.Money - 10000);
                 for (int i = 0; i < skill.Professions.Count; i++)
                 {
                     skill.Professions[i].UndoImmediateProfessionPerk();


### PR DESCRIPTION
### Summary
In current releases of SpaceCore the Statue of Uncertainty in the sewers attempts to take 20,000g from the player in order to change professions when choosing a modded skill. This doesn't match both the text from the Statue of Uncertainty and the vanilla behaviour of only taking away 10,000g.
This is caused by `line 164` being a duplicate of line `line 162` in `GameLocationPatcher.cs` and both attempting to take away 10,000g from the player's current money (leaving the player with 0g if their money was less than 20,000g).

### Changes
- Removes duplicate `line 164` from `GameLocationPatcher.cs`

### Fixes
- Fixes Statue of Uncertainly charging the player twice for modded skills.