### PR TITLE
[GMCM] Revert OpenListMenuNew to OpenListMenu

### DIFF
--- a/framework/GenericModConfigMenu/Mod.cs
+++ b/framework/GenericModConfigMenu/Mod.cs
@@ -246,7 +246,7 @@ namespace GenericModConfigMenu
                 },
                 returnToList: () =>
                 {
-                    OpenListMenuNew(listScrollRow);
+                    OpenListMenu(listScrollRow);
                 }
             );
 


### PR DESCRIPTION
At the moment using OpenListMenuNew here causes mods using the API to open their config menu to get stuck in a menu loop due to the behavior of the ActiveConfigMenu setter.

Based on commits, this was supposed to be reverted previously.
