### PR TITLE
[SpaceCore] Feature: IngredientMatcher usability

### DIFF
--- a/SpaceCore/CustomCraftingRecipe.cs
+++ b/SpaceCore/CustomCraftingRecipe.cs
@@ -17,8 +17,8 @@ namespace SpaceCore
 
         public abstract class IngredientMatcher
         {
-            public abstract string DispayName { get; }
-
+            public abstract string DisplayName { get; }
+            
             public abstract Texture2D IconTexture { get; }
             public abstract Rectangle? IconSubrect { get; }
 
@@ -37,30 +37,29 @@ namespace SpaceCore
             }
 
             public abstract void Consume(IList<IInventory> additionalIngredients);
+
+            public abstract bool Matches(Item item);
         }
 
-        public class ObjectIngredientMatcher : IngredientMatcher
+        public class ItemIngredientMatcher : IngredientMatcher
         {
-            private readonly Item dummyObj;
-            private readonly string objectIndex;
-            private readonly int qty;
+            private readonly Item _item;
+            private readonly string _itemId;
+            private readonly int _quantity;
 
-            public ObjectIngredientMatcher( string index, int quantity )
+            public ItemIngredientMatcher(string query, int quantity)
             {
-                string origIndex = index;
-                if (!index.StartsWith("("))
-                    index = $"(O){index}";
+                this._itemId = query;
+                this._quantity = quantity;
 
-                this.dummyObj = ItemRegistry.Create(index, quantity);
-                this.objectIndex = origIndex;
-                this.qty = quantity;
+                this._item = ItemRegistry.Create(this._itemId);
             }
 
-            public override string DispayName
+            public override string DisplayName
             {
                 get
                 {
-                    if (int.TryParse( this.objectIndex, out int i ) && i < 0)
+                    if (int.TryParse(this._itemId, out int i ) && i < 0)
                     {
                         return i switch
                         {
@@ -74,22 +73,22 @@ namespace SpaceCore
                             _ => "???",
                         };
                     }
-                    return dummyObj.DisplayName;
+                    return _item.DisplayName;
                 }
             }
 
-            public override Texture2D IconTexture => ItemRegistry.GetDataOrErrorItem( dummyObj.QualifiedItemId ).GetTexture();
+            public override Texture2D IconTexture => ItemRegistry.GetDataOrErrorItem(_item.QualifiedItemId).GetTexture();
 
-            public override Rectangle? IconSubrect => ItemRegistry.GetDataOrErrorItem(dummyObj.QualifiedItemId).GetSourceRect(0, dummyObj.ParentSheetIndex);
+            public override Rectangle? IconSubrect => ItemRegistry.GetDataOrErrorItem(_item.QualifiedItemId).GetSourceRect();
 
-            public override int Quantity => qty;
+            public override int Quantity => this._quantity;
 
             public override int GetAmountInList(IList<Item> items)
             {
                 int ret = 0;
                 foreach ( var item in items )
                 {
-                    if (this.ItemMatches(item))
+                    if (this.Matches(item))
                         ret += item.Stack;
                 }
 
@@ -98,11 +97,11 @@ namespace SpaceCore
 
             public override void Consume(IList<IInventory> additionalIngredients)
             {
-                int left = this.qty;
+                int left = this._quantity;
                 for ( int i = Game1.player.Items.Count - 1; i >= 0; --i )
                 {
                     var item = Game1.player.Items[i];
-                    if (this.ItemMatches( item ) )
+                    if (this.Matches(item))
                     {
                         int amt = Math.Min(left, item.Stack);
                         left -= amt;
@@ -123,7 +122,7 @@ namespace SpaceCore
                         for (int i = chest.Count - 1; i >= 0; --i)
                         {
                             var item = chest[i];
-                            if (this.ItemMatches( item ) )
+                            if (this.Matches(item))
                             {
                                 int amt = Math.Min(left, item.Stack);
                                 left -= amt;
@@ -147,16 +146,16 @@ namespace SpaceCore
                 }
             }
 
-            private bool ItemMatches(Item item)
+            public override bool Matches(Item item)
             {
                 if (item == null)
                     return false;
 
-                if (item is StardewValley.Object obj2 && objectIndex.StartsWith("-"))
+                if (item is StardewValley.Object o && this._itemId.StartsWith("-"))
                 {
-                    return obj2.Category == int.Parse(objectIndex);
+                    return o.Category == int.Parse(this._itemId);
                 }
-                return item.canStackWith(dummyObj);
+                return item.canStackWith(this._item);
             }
         }
 

--- a/SpaceCore/Framework/CustomCraftingRecipe.cs
+++ b/SpaceCore/Framework/CustomCraftingRecipe.cs
@@ -69,7 +69,7 @@ namespace SpaceCore.Framework
                         required_count -= containers_count;
                     }
                 }
-                string ingredient_name_text = ingred.DispayName;
+                string ingredient_name_text = ingred.DisplayName;
                 Color drawColor = ((required_count <= 0) ? Game1.textColor : Color.Red);
                 b.Draw(ingred.IconTexture, new Vector2(position.X, position.Y + 64f + (float)(i * 64 / 2) + (float)(i * 4)), ingred.IconSubrect, Color.White, 0f, Vector2.Zero, 2f, SpriteEffects.None, 0.86f);
                 Utility.drawTinyDigits(ingred.Quantity, b, new Vector2(position.X + 32f - Game1.tinyFont.MeasureString(ingred.Quantity.ToString() ?? "").X, position.Y + 64f + (float)(i * 64 / 2) + (float)(i * 4) + 21f), 2f, 0.87f, Color.AntiqueWhite);

--- a/SpaceCore/VanillaAssetExpansion/VAECraftingRecipe.cs
+++ b/SpaceCore/VanillaAssetExpansion/VAECraftingRecipe.cs
@@ -47,7 +47,7 @@ namespace SpaceCore.VanillaAssetExpansion
 
         public VAECraftingRecipe.IngredientData Data => data;
 
-        public override string DispayName => data.OverrideText ?? ItemRegistry.GetDataOrErrorItem(data.Value).DisplayName;
+        public override string DisplayName => data.OverrideText ?? ItemRegistry.GetDataOrErrorItem(data.Value).DisplayName;
 
         public override Texture2D IconTexture => data.OverrideTexturePath != null ? Game1.content.Load<Texture2D>(data.OverrideTexturePath) : ItemRegistry.GetDataOrErrorItem(data.Value).GetTexture();
 
@@ -110,18 +110,18 @@ namespace SpaceCore.VanillaAssetExpansion
             return items.Sum(i => Matches(i) ? i.Stack : 0);
         }
 
-        private bool Matches(Item i)
+        public override bool Matches(Item item)
         {
-            if (i == null)
+            if (item == null)
                 return false;
 
             switch (data.Type)
             {
                 case VAECraftingRecipe.IngredientData.IngredientType.Item:
-                    return i.QualifiedItemId == data.Value;
+                    return item.QualifiedItemId == data.Value;
                 case VAECraftingRecipe.IngredientData.IngredientType.ContextTag:
                     var tags = data.Value.Split(',').Select(s => s.Trim());
-                    return data.ContextTagsRequireAll ? tags.All(s => i.HasContextTag(s)) : tags.Any(s => i.HasContextTag(s));
+                    return data.ContextTagsRequireAll ? tags.All(s => item.HasContextTag(s)) : tags.Any(s => item.HasContextTag(s));
             }
 
             return false;

--- a/SpaceCore/VanillaAssetExpansion/VAECraftingRecipe.cs
+++ b/SpaceCore/VanillaAssetExpansion/VAECraftingRecipe.cs
@@ -145,26 +145,7 @@ namespace SpaceCore.VanillaAssetExpansion
 
         public VAECraftingRecipe Data => data;
 
-        public override string Description
-        {
-            get
-            {
-                Dictionary<string, string> dict = CraftingRecipe.craftingRecipes;
-                int ind = CraftingRecipe.index_craftingDisplayName;
-                if (cooking)
-                {
-                    dict = CraftingRecipe.cookingRecipes;
-                    ind = CraftingRecipe.index_cookingDisplayName;
-                }
-
-                string[] split = dict[id].Split('/');
-                if (ind < split.Length)
-                    return split[ind];
-
-                // Why are we using displayname here? I dunno, the old code returned the display name...
-                return ItemRegistry.GetDataOrErrorItem(data.ProductQualifiedId).DisplayName;
-            }
-        }
+        public override string Description => ItemRegistry.GetDataOrErrorItem(data.ProductQualifiedId).Description ?? string.Empty;
 
         public override Texture2D IconTexture => ItemRegistry.GetDataOrErrorItem(data.ProductQualifiedId).GetTexture();
 


### PR DESCRIPTION
### Summary
Exposes some members of IngredientMatcher for better usability from other mods (i.e. Love of Cooking, as usual) and improves readability a little.
### Changes
- Adds `public abstract Matches(Item item)` method to `IngredientMatcher` to allow external mods to compare items for crafting.
- Renames some members to better represent their purpose (e.g. `objectIndex` -> `_itemId`, or `ObjectIngredientMatcher` -> `ItemIngredientMatcher`).
### Fixes
- Fixes some typos (e.g. `IngredientMatcher.DispayName`).
- Fixes `VAECustomCraftingRecipe.Description` returning item display name instead of description.