### PR TITLE
[Spacecore] Fixed Statue of Uncertainty doing all skill profession's [UndoImmediateProfessionPerk()]

### DIFF
--- a/framework/SpaceCore/Patches/GameLocationPatcher.cs
+++ b/framework/SpaceCore/Patches/GameLocationPatcher.cs
@@ -164,8 +164,11 @@ namespace SpaceCore.Patches
                 Game1.player.Money = Math.Max(0, Game1.player.Money - 10000);
                 for (int i = 0; i < skill.Professions.Count; i++)
                 {
-                    skill.Professions[i].UndoImmediateProfessionPerk();
-                    Game1.player.professions.Remove(skill.Professions[i].GetVanillaId());
+                    if (Game1.player.professions.Contains(skill.Professions[i].GetVanillaId()))
+                    {
+                        skill.Professions[i].UndoImmediateProfessionPerk();
+                        Game1.player.professions.Remove(skill.Professions[i].GetVanillaId());
+                    }
                 }
                 Game1.drawObjectDialogue(Game1.content.LoadString("Strings\\Locations:Sewer_DogStatueFinished"));
                 int level = Skills.GetSkillLevel(Game1.player, skill.Id);

--- a/framework/SpaceCore/Patches/GameLocationPatcher.cs
+++ b/framework/SpaceCore/Patches/GameLocationPatcher.cs
@@ -164,10 +164,9 @@ namespace SpaceCore.Patches
                 Game1.player.Money = Math.Max(0, Game1.player.Money - 10000);
                 for (int i = 0; i < skill.Professions.Count; i++)
                 {
-                    if (Game1.player.professions.Contains(skill.Professions[i].GetVanillaId()))
+                    if (Game1.player.professions.Remove(skill.Professions[i].GetVanillaId()))
                     {
                         skill.Professions[i].UndoImmediateProfessionPerk();
-                        Game1.player.professions.Remove(skill.Professions[i].GetVanillaId());
                     }
                 }
                 Game1.drawObjectDialogue(Game1.content.LoadString("Strings\\Locations:Sewer_DogStatueFinished"));


### PR DESCRIPTION
Statue of Uncertainty would go through and do all the [UndoImmediateProfessionPerk()], even if you didn't have profession. This change makes it so it only does the perks you lost. 