### PR TITLE
[SpaceCore] Update guidebook font when changing locale

### DIFF
--- a/framework/SpaceCore/SpaceCore.cs
+++ b/framework/SpaceCore/SpaceCore.cs
@@ -1076,6 +1076,12 @@ namespace SpaceCore
             GuidebookFont.Fonts.Add("default", Game1.smallFont);
             GuidebookFont.Fonts.Add("tiny", Game1.tinyFont);
             GuidebookFont.Fonts.Add("dialogue", Game1.dialogueFont);
+            LocalizedContentManager.OnLanguageChange += code =>
+            {
+                GuidebookFont.Fonts["default"] = Game1.smallFont;
+                GuidebookFont.Fonts["tiny"] = Game1.tinyFont;
+                GuidebookFont.Fonts["dialogue"] = Game1.dialogueFont;
+            };
 
             api = Helper.ModRegistry.GetApi<IApi>(ModManifest.UniqueID);
             api.RegisterCustomProperty(typeof(Farmer), "SpaceCore_ExtraEquippables", typeof(NetStringDictionary<Item, NetRef<Item>>), AccessTools.Method(typeof(FarmerExtData), nameof(FarmerExtData.get_equippables)), AccessTools.Method(typeof(FarmerExtData), nameof(FarmerExtData.set_equippables)));


### PR DESCRIPTION
Changed branch for https://github.com/spacechase0/StardewValleyMods/pull/521

Currently spacecore guidebooks do not respond to locale changes, which causes the font to be always english and incompatible with translations.
