### PR TITLE
[Spacecore] Prevents excessive buff Width

### DIFF
--- a/framework/SpaceCore/Patches/SkillBuffPatcher.cs
+++ b/framework/SpaceCore/Patches/SkillBuffPatcher.cs
@@ -276,6 +276,7 @@ internal class SkillBuffPatcher : BasePatcher
         {
             return width;
         }
+
         foreach (var buffData in data.Buffs)
         {
             if (SkillBuff.TryGetAdditionalBuffEffects(buffData.CustomFields, out var skills, out float health, out float stamina))

--- a/framework/SpaceCore/Patches/SkillBuffPatcher.cs
+++ b/framework/SpaceCore/Patches/SkillBuffPatcher.cs
@@ -276,7 +276,6 @@ internal class SkillBuffPatcher : BasePatcher
         {
             return width;
         }
-
         foreach (var buffData in data.Buffs)
         {
             if (SkillBuff.TryGetAdditionalBuffEffects(buffData.CustomFields, out var skills, out float health, out float stamina))
@@ -285,6 +284,13 @@ internal class SkillBuffPatcher : BasePatcher
                 {
                     Skills.Skill skill = Skills.GetSkill(entry.Key);
                     if (skill is null)
+                        continue;
+
+                    // Prevents the tooltip from growing too wide.
+                    // The longest (english) skill name atm that fits on the skill screen without clipping is at 11-12 characters.
+                    // An 11 to 12 character name makes the width around 284.
+                    // made the check 290 to try to accomidate other languages!
+                    if (width > 290)
                         continue;
 
                     width = Math.Max(width, (int)font.MeasureString("+99 " + skill.GetName()).X) + 92;
@@ -299,6 +305,8 @@ internal class SkillBuffPatcher : BasePatcher
                 }
             }
         }
+        Log.Warn("TESTERS");
+        Log.Warn($"{width}");
 
         return width;
     }

--- a/framework/SpaceCore/Patches/SkillBuffPatcher.cs
+++ b/framework/SpaceCore/Patches/SkillBuffPatcher.cs
@@ -305,8 +305,6 @@ internal class SkillBuffPatcher : BasePatcher
                 }
             }
         }
-        Log.Warn("TESTERS");
-        Log.Warn($"{width}");
 
         return width;
     }

--- a/framework/SpaceCore/Patches/SkillBuffPatcher.cs
+++ b/framework/SpaceCore/Patches/SkillBuffPatcher.cs
@@ -287,22 +287,15 @@ internal class SkillBuffPatcher : BasePatcher
                     if (skill is null)
                         continue;
 
-                    // Prevents the tooltip from growing too wide.
-                    // The longest (english) skill name atm that fits on the skill screen without clipping is at 11-12 characters.
-                    // An 11 to 12 character name makes the width around 284.
-                    // made the check 290 to try to accomidate other languages!
-                    if (width > 290)
-                        continue;
-
-                    width = Math.Max(width, (int)font.MeasureString("+99 " + skill.GetName()).X) + 92;
+                    width = Math.Max(width, (int)font.MeasureString("+99 " + skill.GetName()).X + 92 );
                 }
                 if (health != 0)
                 {
-                    width = Math.Max(width, (int)font.MeasureString("+999 " + I18n.HealthRegen()).X) + 92;
+                    width = Math.Max(width, (int)font.MeasureString("+999 " + I18n.HealthRegen()).X + 92);
                 }
                 if (stamina != 0)
                 {
-                    width = Math.Max(width, (int)font.MeasureString("+999 " + I18n.StaminaRegen()).X) + 92;
+                    width = Math.Max(width, (int)font.MeasureString("+999 " + I18n.StaminaRegen()).X + 92);
                 }
             }
         }


### PR DESCRIPTION
prevents excessive width if you have multiple custom skillbuffs on a food item. 

See example of the error. 

Before:
![20251019181814_1](https://github.com/user-attachments/assets/ecd7eb9f-b667-4f44-ab1b-ed09282d8474)

After
![20251019183448_1](https://github.com/user-attachments/assets/4fa009ee-ca3b-4b58-a8c9-ebaffd73496d)
