### PR TITLE
Add search/filter functionality to Generic Mod Config Menu

### DIFF
--- a/framework/GenericModConfigMenu/Framework/ModConfigMenu.cs
+++ b/framework/GenericModConfigMenu/Framework/ModConfigMenu.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
 using SpaceShared;
 using SpaceShared.UI;
 using StardewModdingAPI;
@@ -11,6 +12,61 @@ using StardewValley.Menus;
 
 namespace GenericModConfigMenu.Framework
 {
+    /// <summary>Textbox with customizable width for search functionality.</summary>
+    internal class WideTextbox : Textbox
+    {
+        private readonly int CustomWidth;
+
+        public WideTextbox(int width)
+        {
+            this.CustomWidth = width;
+        }
+
+        public override int Width => this.CustomWidth;
+
+        public override void Update(bool isOffScreen = false)
+        {
+            base.Update(isOffScreen);
+
+            // Handle click to select/deselect
+            if (this.ClickGestured)
+            {
+                this.Selected = this.Hover;
+                if (this.Callback != null)
+                    this.Callback(this);
+            }
+        }
+
+        public override void Draw(SpriteBatch b)
+        {
+            if (this.IsHidden())
+                return;
+
+            // Draw textbox background using drawTextureBox so it scales properly
+            IClickableMenu.drawTextureBox(b, 
+                Game1.menuTexture, 
+                new Rectangle(0, 256, 60, 60), 
+                (int)this.Position.X, 
+                (int)this.Position.Y, 
+                this.CustomWidth, 
+                48, 
+                Color.White);
+
+            // Draw the text
+            string text = this.String;
+            Vector2 textSize;
+            int maxWidth = this.CustomWidth - 32; // Subtract margins
+            for (textSize = Game1.smallFont.MeasureString(text); textSize.X > maxWidth; textSize = Game1.smallFont.MeasureString(text))
+                text = text.Substring(1);
+
+            // Draw blinking cursor if selected
+            if (DateTime.UtcNow.Millisecond % 1000 >= 500 && this.Selected)
+                b.Draw(Game1.staminaRect, new Rectangle((int)this.Position.X + 16 + (int)textSize.X + 2, (int)this.Position.Y + 8, 4, 32), Game1.textColor);
+
+            b.DrawString(Game1.smallFont, text, this.Position + new Vector2(16, 12), Game1.textColor);
+        }
+    }
+
     internal class ModConfigMenu : IClickableMenu
     {
         /*********
@@ -18,6 +74,12 @@ namespace GenericModConfigMenu.Framework
         *********/
         private RootElement Ui;
         private readonly Table Table;
+
+        /*********
+        ** Accessors
+        *********/
+        /// <summary>Whether the search textbox is currently active (typing).</summary>
+        public bool IsTypingInSearchBox => this.SearchBox != null && this.SearchBox.Selected;
 
         /// <summary>The number of field rows to offset when scrolling a config menu.</summary>
         private readonly int ScrollSpeed;
@@ -27,6 +89,21 @@ namespace GenericModConfigMenu.Framework
         private bool InGame => Context.IsWorldReady;
 
         private List<Label> LabelsWithTooltips = new();
+
+        /// <summary>The search textbox for filtering mods.</summary>
+        private Textbox SearchBox;
+
+        /// <summary>The current search query.</summary>
+        private string CurrentSearchQuery = "";
+
+        /// <summary>The last search query that was processed.</summary>
+        private string LastProcessedSearchQuery = "";
+
+        /// <summary>The placeholder label for the search box.</summary>
+        private Label SearchPlaceholder;
+
+        /// <summary>All mod configs available for display.</summary>
+        private readonly ModConfigManager AllConfigs;
 
 
         /*********
@@ -54,84 +131,48 @@ namespace GenericModConfigMenu.Framework
         {
             this.ScrollSpeed = scrollSpeed;
             this.OpenModMenu = openModMenu;
+            this.AllConfigs = configs;
 
             // init UI
             this.Ui = new RootElement();
+
+            // Table width (standard size)
+            int tableWidth = 800;
+            // Search bar width = full UI width (table + 64px borders on each side)
+            int searchWidth = tableWidth + 128;
+
+            // Create search box (at the top, same width as full UI with margin)
+            this.SearchBox = new WideTextbox(searchWidth)
+            {
+                LocalPosition = new Vector2((Game1.uiViewport.Width - searchWidth) / 2, 16),
+                String = "",
+                Callback = _ => this.OnSearchChanged()
+            };
+            this.Ui.AddChild(this.SearchBox);
+            
+            // Automatically activate textbox so user can type immediately
+            this.SearchBox.Selected = true;
+
+            // Create search placeholder (will be hidden when typing) - black text
+            this.SearchPlaceholder = new Label
+            {
+                String = I18n.List_SearchLabel(),
+                LocalPosition = new Vector2((Game1.uiViewport.Width - searchWidth) / 2 + 20, 20),
+                NonBoldScale = 0.8f,
+                IdleTextColor = Color.Black * 0.6f,
+                HoverTextColor = Color.Black * 0.6f
+            };
+            this.Ui.AddChild(this.SearchPlaceholder);
+
             this.Table = new Table
             {
                 RowHeight = 50,
-                LocalPosition = new Vector2((Game1.uiViewport.Width - 800) / 2, 64),
-                Size = new Vector2(800, Game1.uiViewport.Height - 128)
+                LocalPosition = new Vector2((Game1.uiViewport.Width - tableWidth) / 2, 64 + 50),
+                Size = new Vector2(tableWidth, Game1.uiViewport.Height - 128 - 50)
             };
 
-            // editable mods section
-            {
-                // heading
-                var heading = new Label
-                {
-                    String = I18n.List_EditableHeading(),
-                    Bold = true
-                };
-                heading.LocalPosition = new Vector2((800 - heading.Measure().X) / 2, heading.LocalPosition.Y);
-                this.Table.AddRow(new Element[] { heading });
-
-                // mod list
-                {
-                    ModConfig[] editable = configs
-                        .GetAll()
-                        .Where(entry => entry.AnyEditableInGame || !this.InGame)
-                        .OrderBy(entry => entry.ModName)
-                        .ToArray();
-
-                    foreach (ModConfig entry in editable)
-                    {
-                        Label label = new Label
-                        {
-                            String = entry.ModName,
-                            UserData = entry.ModManifest.Description,
-                            Callback = _ => this.ChangeToModPage(entry.ModManifest)
-                        };
-                        this.Table.AddRow(new Element[] { label });
-                        LabelsWithTooltips.Add(label);
-                    }
-                }
-            }
-
-            // non-editable mods heading
-            {
-                ModConfig[] notEditable = configs
-                    .GetAll()
-                    .Where(entry => !entry.AnyEditableInGame && this.InGame)
-                    .OrderBy(entry => entry.ModName)
-                    .ToArray();
-
-                if (notEditable.Any())
-                {
-                    // heading
-                    var heading = new Label
-                    {
-                        String = I18n.List_NotEditableHeading(),
-                        Bold = true
-                    };
-                    this.Table.AddRow(Array.Empty<Element>());
-                    this.Table.AddRow(new Element[] { heading });
-
-                    // mod list
-                    foreach (ModConfig entry in notEditable)
-                    {
-                        Label label = new Label
-                        {
-                            String = entry.ModName,
-                            UserData = entry.ModManifest.Description,
-                            IdleTextColor = Color.Black * 0.4f,
-                            HoverTextColor = Color.Black * 0.4f
-                        };
-
-                        this.Table.AddRow(new Element[] { label });
-                        LabelsWithTooltips.Add(label);
-                    }
-                }
-            }
+            // Populate initial list
+            this.RebuildModList();
 
             this.Ui.AddChild(this.Table);
 
@@ -166,6 +207,38 @@ namespace GenericModConfigMenu.Framework
                     Game1.playSound("bigDeSelect");
 
                 Mod.ActiveConfigMenu = null;
+                return;
+            }
+
+            // If clicked outside the textbox, deselect it
+            if (this.SearchBox != null && this.SearchBox.Selected)
+            {
+                Rectangle searchBoxBounds = new Rectangle(
+                    (int)this.SearchBox.Position.X,
+                    (int)this.SearchBox.Position.Y,
+                    this.SearchBox.Width,
+                    this.SearchBox.Height
+                );
+
+                if (!searchBoxBounds.Contains(x, y))
+                {
+                    this.SearchBox.Selected = false;
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public override void receiveKeyPress(Keys key)
+        {
+            // If textbox is active, don't process escape key here
+            // The textbox will handle its own input through Game1.keyboardDispatcher
+            if (this.SearchBox != null && this.SearchBox.Selected)
+                return;
+
+            // Only process Escape when not typing
+            if (key == Keys.Escape)
+            {
+                Mod.ActiveConfigMenu = null;
             }
         }
 
@@ -181,6 +254,12 @@ namespace GenericModConfigMenu.Framework
         {
             base.update(time);
             this.Ui.Update();
+
+            // Hide placeholder when typing
+            if (this.SearchPlaceholder != null)
+            {
+                this.SearchPlaceholder.ForceHide = () => !string.IsNullOrEmpty(this.SearchBox.String);
+            }
 
             if (Game1.input.GetGamePadState().ThumbSticks.Right.Y != 0)
             {
@@ -227,8 +306,21 @@ namespace GenericModConfigMenu.Framework
 
             this.Ui = new RootElement();
 
-            Vector2 newSize = new Vector2(800, Game1.uiViewport.Height - 128);
-            this.Table.LocalPosition = new Vector2((Game1.uiViewport.Width - 800) / 2, 64);
+            // Table width (standard size)
+            int tableWidth = 800;
+            // Search bar width = full UI width (table + 64px borders on each side)
+            int searchWidth = tableWidth + 128;
+
+            // Reposition search box (at the top, same width as full UI with margin)
+            this.SearchBox.LocalPosition = new Vector2((Game1.uiViewport.Width - searchWidth) / 2, 16);
+            this.Ui.AddChild(this.SearchBox);
+
+            // Re-add search placeholder
+            this.SearchPlaceholder.LocalPosition = new Vector2((Game1.uiViewport.Width - searchWidth) / 2 + 20, 20);
+            this.Ui.AddChild(this.SearchPlaceholder);
+
+            Vector2 newSize = new Vector2(tableWidth, Game1.uiViewport.Height - 128 - 50);
+            this.Table.LocalPosition = new Vector2((Game1.uiViewport.Width - tableWidth) / 2, 64 + 50);
             foreach (Element opt in this.Table.Children)
                 opt.LocalPosition = new Vector2(newSize.X / (this.Table.Size.X / opt.LocalPosition.X), opt.LocalPosition.Y);
 
@@ -238,6 +330,7 @@ namespace GenericModConfigMenu.Framework
 
             var b = oldUi.Children.First(e => e is Button);
             oldUi.RemoveChild(b);
+            b.LocalPosition = this.Table.LocalPosition - new Vector2(b.Width / 2 + 32, 0);
             this.Ui.AddChild(b);
         }
 
@@ -256,6 +349,152 @@ namespace GenericModConfigMenu.Framework
             Game1.playSound("bigSelect");
 
             this.OpenModMenu(modManifest, this.ScrollRow);
+        }
+
+        /// <summary>Called when the search text changes.</summary>
+        private void OnSearchChanged()
+        {
+            this.CurrentSearchQuery = this.SearchBox.String;
+            
+            // Only rebuild if the text actually changed
+            if (this.CurrentSearchQuery != this.LastProcessedSearchQuery)
+            {
+                this.LastProcessedSearchQuery = this.CurrentSearchQuery;
+                this.RebuildModList();
+            }
+        }
+
+        /// <summary>Clears all rows from the table.</summary>
+        private void ClearTable()
+        {
+            // Use reflection to access the private rows list
+            var rowsField = typeof(Table).GetField("Rows", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            if (rowsField != null)
+            {
+                var rows = rowsField.GetValue(this.Table) as System.Collections.Generic.List<Element[]>;
+                if (rows != null)
+                {
+                    // Remove all children except the scrollbar
+                    foreach (var row in rows.ToArray())
+                    {
+                        foreach (var element in row)
+                        {
+                            this.Table.RemoveChild(element);
+                        }
+                    }
+                    rows.Clear();
+                }
+            }
+        }
+
+        /// <summary>Rebuilds the mod list based on the current search query.</summary>
+        private void RebuildModList()
+        {
+            this.LabelsWithTooltips.Clear();
+            this.ClearTable();
+
+            string searchQuery = this.CurrentSearchQuery.ToLower().Trim();
+
+            // Get filtered mods
+            ModConfig[] allMods = this.AllConfigs.GetAll().ToArray();
+            ModConfig[] filteredMods = allMods;
+
+            if (!string.IsNullOrWhiteSpace(searchQuery))
+            {
+                filteredMods = allMods
+                    .Where(entry =>
+                        entry.ModName.ToLower().Contains(searchQuery) ||
+                        (entry.ModManifest.Description?.ToLower().Contains(searchQuery) ?? false)
+                    )
+                    .ToArray();
+            }
+
+            // Editable mods section
+            {
+                ModConfig[] editable = filteredMods
+                    .Where(entry => entry.AnyEditableInGame || !this.InGame)
+                    .OrderBy(entry => entry.ModName)
+                    .ToArray();
+
+                if (editable.Any())
+                {
+                    // heading
+                    var heading = new Label
+                    {
+                        String = I18n.List_EditableHeading(),
+                        Bold = true
+                    };
+                    heading.LocalPosition = new Vector2((800 - heading.Measure().X) / 2, heading.LocalPosition.Y);
+                    this.Table.AddRow(new Element[] { heading });
+
+                    // mod list
+                    foreach (ModConfig entry in editable)
+                    {
+                        Label label = new Label
+                        {
+                            String = entry.ModName,
+                            UserData = entry.ModManifest.Description,
+                            Callback = _ => this.ChangeToModPage(entry.ModManifest)
+                        };
+                        this.Table.AddRow(new Element[] { label });
+                        this.LabelsWithTooltips.Add(label);
+                    }
+                }
+            }
+
+            // Non-editable mods section
+            {
+                ModConfig[] notEditable = filteredMods
+                    .Where(entry => !entry.AnyEditableInGame && this.InGame)
+                    .OrderBy(entry => entry.ModName)
+                    .ToArray();
+
+                if (notEditable.Any())
+                {
+                    // heading
+                    var heading = new Label
+                    {
+                        String = I18n.List_NotEditableHeading(),
+                        Bold = true
+                    };
+                    this.Table.AddRow(Array.Empty<Element>());
+                    this.Table.AddRow(new Element[] { heading });
+
+                    // mod list
+                    foreach (ModConfig entry in notEditable)
+                    {
+                        Label label = new Label
+                        {
+                            String = entry.ModName,
+                            UserData = entry.ModManifest.Description,
+                            IdleTextColor = Color.Black * 0.4f,
+                            HoverTextColor = Color.Black * 0.4f
+                        };
+
+                        this.Table.AddRow(new Element[] { label });
+                        this.LabelsWithTooltips.Add(label);
+                    }
+                }
+            }
+
+            // Show "no results" message if search returned nothing
+            if (!filteredMods.Any() && !string.IsNullOrWhiteSpace(searchQuery))
+            {
+                var noResultsLabel = new Label
+                {
+                    String = I18n.List_NoResults(),
+                    IdleTextColor = Color.Gray,
+                    HoverTextColor = Color.Gray
+                };
+                noResultsLabel.LocalPosition = new Vector2((800 - noResultsLabel.Measure().X) / 2, noResultsLabel.LocalPosition.Y);
+                this.Table.AddRow(new Element[] { noResultsLabel });
+            }
+
+            // Reset scroll to top only when there's an active search
+            if (!string.IsNullOrWhiteSpace(searchQuery))
+            {
+                this.ScrollRow = 0;
+            }
         }
     }
 }

--- a/framework/GenericModConfigMenu/i18n/default.json
+++ b/framework/GenericModConfigMenu/i18n/default.json
@@ -30,5 +30,9 @@
     "options.open-menu-key.name": "Open menu key",
     "options.open-menu-key.desc": "A keybind which opens the menu.",
     "options.scroll-speed.name": "Scroll speed",
-    "options.scroll-speed.desc": "The number of field rows to offset when scrolling a config menu."
+    "options.scroll-speed.desc": "The number of field rows to offset when scrolling a config menu.",
+
+     //Search Box
+    "list.search-label": "Search:",
+    "list.no-results": "No mods found"
 }

--- a/framework/GenericModConfigMenu/i18n/es.json
+++ b/framework/GenericModConfigMenu/i18n/es.json
@@ -30,5 +30,9 @@
     "options.open-menu-key.name": "Tecla de abrir menú",
     "options.open-menu-key.desc": "La tecla que abre el menú.",
     "options.scroll-speed.name": "Velocidad de desplazamiento",
-    "options.scroll-speed.desc": "El número de filas a desplazar cuando se desplaza un menú de configuración."
+    "options.scroll-speed.desc": "El número de filas a desplazar cuando se desplaza un menú de configuración.",
+
+     //Search Box
+    "list.search-label": "Buscar:",
+    "list.no-results": "No se encontraron mods"
 }


### PR DESCRIPTION
## Description
Adds a search bar to the main Generic Mod Config Menu that allows filtering mods by name or description in real-time.

## Changes
- Added `WideTextbox` custom class with customizable width
- Implemented real-time filtering of the mod list
- Search by mod name or description
- Localizable placeholder text (English and Spanish included)
- Proper keyboard focus handling
- Textbox is automatically activated when opening the menu
- "No results" message when no matches are found

## Benefits
- Significantly improves UX when many mods are installed
- Makes it easy to quickly find specific configurations
- Works both in the title menu and during gameplay

## Modified Files
- `Framework/ModConfigMenu.cs` - Main functionality
- `i18n/default.json` - English translations
- `i18n/es.json` - Spanish translations

## TODO
- Translate the new keys into the other languages

## Testing
Tested with multiple mods installed, works correctly in both contexts (title and in-game).

---

**Note:** My Nexus Mods username is "mahsouto"