### PR TITLE
Add gamepad snap navigation to Generic Mod Config Menu

### DIFF
--- a/framework/GenericModConfigMenu/Framework/ModConfigMenu.cs
+++ b/framework/GenericModConfigMenu/Framework/ModConfigMenu.cs
@@ -74,6 +74,7 @@ namespace GenericModConfigMenu.Framework
         *********/
         private RootElement Ui;
         private readonly Table Table;
+        private TableNavigator Navigator;
 
         /*********
         ** Accessors
@@ -84,8 +85,8 @@ namespace GenericModConfigMenu.Framework
         /// <summary>The number of field rows to offset when scrolling a config menu.</summary>
         private readonly int ScrollSpeed;
 
-        /// <summary>Open the config UI for a specific mod.</summary>
-        private readonly Action<IManifest, int> OpenModMenu;
+        /// <summary>Open the config UI for a specific mod. Parameters: manifest, scrollRow, focusedRow.</summary>
+        private readonly Action<IManifest, int, int> OpenModMenu;
         private bool InGame => Context.IsWorldReady;
 
         private List<Label> LabelsWithTooltips = new();
@@ -127,7 +128,7 @@ namespace GenericModConfigMenu.Framework
         /// <param name="keybindsTexture">The icon texture for the keybinds menu.</param>
         /// <param name="configs">The mod configurations to display.</param>
         /// <param name="scrollTo">The initial scroll position, represented by the row index at the top of the visible area.</param>
-        public ModConfigMenu(int scrollSpeed, Action<IManifest, int> openModMenu, Action<int> openKeybindsMenu, ModConfigManager configs, Texture2D keybindsTexture, int? scrollTo = null)
+        public ModConfigMenu(int scrollSpeed, Action<IManifest, int, int> openModMenu, Action<int> openKeybindsMenu, ModConfigManager configs, Texture2D keybindsTexture, int? scrollTo = null, int? focusRow = null)
         {
             this.ScrollSpeed = scrollSpeed;
             this.OpenModMenu = openModMenu;
@@ -196,6 +197,27 @@ namespace GenericModConfigMenu.Framework
                 // This hack lets gamepad cursor movement work without a harmony patch
                 Mod.instance.Helper.Reflection.GetField<bool>(Game1.activeClickableMenu, "titleInPosition").SetValue(false);
             }
+
+            // Controller navigation
+            this.Navigator = new TableNavigator(this.Table)
+            {
+                OnBack = () =>
+                {
+                    Game1.playSound("bigDeSelect");
+                    Mod.ActiveConfigMenu = null;
+                }
+            };
+
+            if (focusRow.HasValue)
+                this.Navigator.CurrentFocusedRow = focusRow.Value;
+        }
+
+        /// <inheritdoc />
+        /// <remarks>Override prevents the base class from closing the menu on B press.
+        /// B is handled by the TableNavigator via update() instead.</remarks>
+        public override void receiveGamePadButton(Buttons b)
+        {
+            // intentionally empty — TableNavigator.HandleB() handles B via OnBack callback
         }
 
         /// <inheritdoc />
@@ -253,7 +275,9 @@ namespace GenericModConfigMenu.Framework
         public override void update(GameTime time)
         {
             base.update(time);
+            this.Navigator?.HandleInput();
             this.Ui.Update();
+            this.Navigator?.SnapAndScroll();
 
             // Hide placeholder when typing
             if (this.SearchPlaceholder != null)
@@ -282,7 +306,7 @@ namespace GenericModConfigMenu.Framework
             if (this.InGame)
                 this.drawMouse(b);
 
-            if (Constants.TargetPlatform != GamePlatform.Android && GetChildMenu() == null)
+            if (GetChildMenu() == null)
             {
                 foreach (var label in this.LabelsWithTooltips)
                 {
@@ -348,7 +372,7 @@ namespace GenericModConfigMenu.Framework
             Log.Trace("Changing to mod config page for mod " + modManifest.UniqueID);
             Game1.playSound("bigSelect");
 
-            this.OpenModMenu(modManifest, this.ScrollRow);
+            this.OpenModMenu(modManifest, this.ScrollRow, this.Navigator?.CurrentFocusedRow ?? -1);
         }
 
         /// <summary>Called when the search text changes.</summary>
@@ -495,6 +519,8 @@ namespace GenericModConfigMenu.Framework
             {
                 this.ScrollRow = 0;
             }
+
+            this.Navigator?.InvalidateRows();
         }
     }
 }

--- a/framework/GenericModConfigMenu/Framework/OwnModConfig.cs
+++ b/framework/GenericModConfigMenu/Framework/OwnModConfig.cs
@@ -13,5 +13,8 @@ namespace GenericModConfigMenu.Framework
 
         /// <summary>The number of field rows to offset when scrolling a config menu.</summary>
         public int ScrollSpeed { get; set; } = 120;
+
+        /// <summary>Whether to enable D-pad/thumbstick snap navigation in config menus when using a controller.</summary>
+        public bool SnapNavigation { get; set; } = true;
     }
 }

--- a/framework/GenericModConfigMenu/Framework/SpecificModConfigMenu.cs
+++ b/framework/GenericModConfigMenu/Framework/SpecificModConfigMenu.cs
@@ -34,6 +34,7 @@ namespace GenericModConfigMenu.Framework
 
         private RootElement Ui = new();
         private readonly Table Table;
+        private TableNavigator Navigator;
         private readonly List<Label> OptHovers = new();
 
         /// <summary>Whether the user hit escape.</summary>
@@ -113,9 +114,6 @@ namespace GenericModConfigMenu.Framework
                     switch (opt)
                     {
                         case SimpleModOption<SButton> option:
-                            if (Constants.TargetPlatform == GamePlatform.Android)
-                                continue; // TODO: Support virtual keyboard input.
-
                             optionElement = new Label
                             {
                                 String = option.FormatValue(),
@@ -126,9 +124,6 @@ namespace GenericModConfigMenu.Framework
                             break;
 
                         case SimpleModOption<KeybindList> option:
-                            if (Constants.TargetPlatform == GamePlatform.Android)
-                                continue; // TODO: Support virtual keyboard input.
-
                             optionElement = new Label
                             {
                                 String = option.FormatValue(),
@@ -153,21 +148,28 @@ namespace GenericModConfigMenu.Framework
                     };
                     if (!string.IsNullOrEmpty(config.ModManifest.Description))
                         OptHovers.Add(header);
-                    Table.AddRow([header]);
+                    Table.AddRow(new Element[] { header });
 
                     foreach (var row in rows)
                         Table.AddRow(row);
 
-                    Table.AddRow([]);
+                    Table.AddRow(Array.Empty<Element>());
                 }
             }
             this.Ui.AddChild(this.Table);
-            this.AddDefaultLabels(null);
+            var bottomButtons = this.AddDefaultLabels(null);
 
             // We need to update widgets at least once so ComplexModOptionWidget's get initialized
             this.Table.ForceUpdateEvenHidden();
 
             RefreshKeybindColor();
+
+            // Controller navigation
+            this.Navigator = new TableNavigator(this.Table)
+            {
+                OnBack = () => this.Cancel(),
+                BottomButtons = bottomButtons
+            };
         }
 
         public SpecificModConfigMenu(ModConfig config, int scrollSpeed, string page, Action<string> openPage, Action returnToList)
@@ -230,9 +232,6 @@ namespace GenericModConfigMenu.Framework
                         break;
 
                     case SimpleModOption<SButton> option:
-                        if (Constants.TargetPlatform == GamePlatform.Android)
-                            continue; // TODO: Support virtual keyboard input.
-
                         optionElement = new Label
                         {
                             String = option.FormatValue(),
@@ -242,9 +241,6 @@ namespace GenericModConfigMenu.Framework
                         break;
 
                     case SimpleModOption<KeybindList> option:
-                        if (Constants.TargetPlatform == GamePlatform.Android)
-                            continue; // TODO: Support virtual keyboard input.
-
                         optionElement = new Label
                         {
                             String = option.FormatValue(),
@@ -453,10 +449,17 @@ namespace GenericModConfigMenu.Framework
 
             }
             this.Ui.AddChild(this.Table);
-            this.AddDefaultLabels(this.Manifest);
+            var bottomButtons = this.AddDefaultLabels(this.Manifest);
 
             // We need to update widgets at least once so ComplexModOptionWidget's get initialized
             this.Table.ForceUpdateEvenHidden();
+
+            // Controller navigation
+            this.Navigator = new TableNavigator(this.Table)
+            {
+                OnBack = () => this.Cancel(),
+                BottomButtons = bottomButtons
+            };
         }
 
         /// <inheritdoc />
@@ -490,23 +493,17 @@ namespace GenericModConfigMenu.Framework
             return false;
         }
 
-        private int scrollCounter = 0;
         /// <inheritdoc />
         public override void update(GameTime time)
         {
             base.update(time);
+            if (!this.IsBindingKey)
+                this.Navigator?.HandleInput();
             this.Ui.Update();
+            if (!this.IsBindingKey)
+                this.Navigator?.SnapAndScroll();
 
-            // TODO: This will be different if a dropdown is open
-            if (Game1.input.GetGamePadState().ThumbSticks.Right.Y != 0)
-            {
-                if (++scrollCounter == 5)
-                {
-                    scrollCounter = 0;
-                    this.Table.Scrollbar.ScrollBy(Math.Sign(Game1.input.GetGamePadState().ThumbSticks.Right.Y) * 120 / -this.ScrollSpeed);
-                }
-            }
-            else scrollCounter = 0;
+            // Right stick scrolling is handled by TableNavigator (navigates rows, EnsureFocusedVisible scrolls)
 
             if (this.ExitOnNextUpdate)
                 this.Cancel();
@@ -537,7 +534,7 @@ namespace GenericModConfigMenu.Framework
             this.drawMouse(b);
 
             // hover tooltips
-            if (Constants.TargetPlatform != GamePlatform.Android && GetChildMenu() == null)
+            if (GetChildMenu() == null)
             {
                 foreach (var label in this.OptHovers)
                 {
@@ -572,7 +569,9 @@ namespace GenericModConfigMenu.Framework
             this.Table.LocalPosition = new Vector2((Game1.uiViewport.Width - this.Table.Size.X) / 2, (Game1.uiViewport.Height - this.Table.Size.Y) / 2);
             this.Table.Scrollbar.Update();
             this.Ui.AddChild(this.Table);
-            this.AddDefaultLabels(this.Manifest);
+            var resizedButtons = this.AddDefaultLabels(this.Manifest);
+            if (this.Navigator != null)
+                this.Navigator.BottomButtons = resizedButtons;
 
             this.ActiveKeybindOverlay?.OnWindowResized();
         }
@@ -600,7 +599,7 @@ namespace GenericModConfigMenu.Framework
         /*********
         ** Private methods
         *********/
-        private void AddDefaultLabels(IManifest modManifest)
+        private Label[] AddDefaultLabels(IManifest modManifest)
         {
             // add page title
             {
@@ -674,6 +673,8 @@ namespace GenericModConfigMenu.Framework
                 // add to UI
                 foreach (var button in buttons)
                     this.Ui.AddChild(button);
+
+                return buttons;
             }
         }
 
@@ -778,7 +779,7 @@ namespace GenericModConfigMenu.Framework
             this.ActiveKeybindOverlay = option switch
             {
                 SimpleModOption<SButton> buttonOption => new KeybindOverlay(
-                    keybinds: [new Keybind(buttonOption.Value)],
+                    keybinds: new[] { new Keybind(buttonOption.Value) },
                     onlyAllowSingleButton: true,
                     name: option.Name(),
                     onSaved: keybinds =>

--- a/framework/GenericModConfigMenu/Mod.cs
+++ b/framework/GenericModConfigMenu/Mod.cs
@@ -151,13 +151,14 @@ namespace GenericModConfigMenu
 
         /// <summary>Open the menu which shows a list of configurable mods.</summary>
         /// <param name="scrollRow">The initial scroll position, represented by the row index at the top of the visible area.</param>
-        private void OpenListMenuNew(int? scrollRow = null)
+        /// <param name="focusRow">The row to focus in the navigator (for restoring selection after returning from a mod config).</param>
+        private void OpenListMenuNew(int? scrollRow = null, int? focusRow = null)
         {
-            Mod.ActiveConfigMenu = new ModConfigMenu(this.Config.ScrollSpeed, openModMenu: (mod, curScrollRow) => this.OpenModMenuNew(mod, page: null, listScrollRow: curScrollRow), openKeybindsMenu: currScrollRow => OpenKeybindsMenuNew( currScrollRow ), this.ConfigManager, this.Helper.GameContent.Load<Texture2D>(AssetManager.KeyboardButton), scrollRow);
+            Mod.ActiveConfigMenu = new ModConfigMenu(this.Config.ScrollSpeed, openModMenu: (mod, curScrollRow, curFocusRow) => this.OpenModMenuNew(mod, page: null, listScrollRow: curScrollRow, listFocusRow: curFocusRow), openKeybindsMenu: currScrollRow => OpenKeybindsMenuNew( currScrollRow ), this.ConfigManager, this.Helper.GameContent.Load<Texture2D>(AssetManager.KeyboardButton), scrollRow, focusRow);
         }
         private void OpenListMenu(int? scrollRow = null)
         {
-            var newMenu = new ModConfigMenu(this.Config.ScrollSpeed, openModMenu: (mod, curScrollRow) => this.OpenModMenuNew(mod, page: null, listScrollRow: curScrollRow), openKeybindsMenu: currScrollRow => OpenKeybindsMenuNew(currScrollRow), this.ConfigManager, this.Helper.GameContent.Load<Texture2D>(AssetManager.KeyboardButton), scrollRow); ;
+            var newMenu = new ModConfigMenu(this.Config.ScrollSpeed, openModMenu: (mod, curScrollRow, curFocusRow) => this.OpenModMenuNew(mod, page: null, listScrollRow: curScrollRow, listFocusRow: curFocusRow), openKeybindsMenu: currScrollRow => OpenKeybindsMenuNew(currScrollRow), this.ConfigManager, this.Helper.GameContent.Load<Texture2D>(AssetManager.KeyboardButton), scrollRow); ;
             if (Game1.activeClickableMenu is TitleMenu)
             {
                 TitleMenu.subMenu = newMenu;
@@ -175,10 +176,10 @@ namespace GenericModConfigMenu
                 scrollSpeed: this.Config.ScrollSpeed,
                 returnToList: () =>
                 {
-                    if (Game1.activeClickableMenu is TitleMenu)
-                        OpenListMenuNew(listScrollRow);
-                    else
+                    Mod.ActiveConfigMenu = null;
+                    if (!(Game1.activeClickableMenu is TitleMenu))
                         Mod.ActiveConfigMenu = null;
+                    OpenListMenuNew(listScrollRow);
                 }
             );
         }
@@ -208,7 +209,8 @@ namespace GenericModConfigMenu
         /// <param name="mod">The mod whose config menu to display.</param>
         /// <param name="page">The page to display within the mod's config menu.</param>
         /// <param name="listScrollRow">The scroll position to set in the mod list when returning to it, represented by the row index at the top of the visible area.</param>
-        private void OpenModMenuNew(IManifest mod, string page, int? listScrollRow)
+        /// <param name="listFocusRow">The row to focus in the mod list navigator when returning.</param>
+        private void OpenModMenuNew(IManifest mod, string page, int? listScrollRow, int listFocusRow = -1)
         {
             ModConfig config = this.ConfigManager.Get(mod, assert: true);
 
@@ -220,14 +222,18 @@ namespace GenericModConfigMenu
                 {
                     if (!(Game1.activeClickableMenu is TitleMenu))
                         Mod.ActiveConfigMenu = null;
-                    this.OpenModMenuNew(mod, newPage, listScrollRow);
+                    this.OpenModMenuNew(mod, newPage, listScrollRow, listFocusRow);
                 },
                 returnToList: () =>
                 {
-                    if (Game1.activeClickableMenu is TitleMenu)
-                        OpenListMenuNew(listScrollRow);
-                    else
+                    // Remove SpecificModConfigMenu from the chain
+                    Mod.ActiveConfigMenu = null;
+                    if (!(Game1.activeClickableMenu is TitleMenu))
+                        // In-game: also remove the stale ModConfigMenu whose navigator
+                        // has outdated PrevPad (wasn't updated while behind SpecificModConfigMenu)
                         Mod.ActiveConfigMenu = null;
+                    // Create fresh ModConfigMenu with synced PrevPad and restored focus
+                    OpenListMenuNew(listScrollRow, listFocusRow);
                 }
             );
         }
@@ -265,7 +271,7 @@ namespace GenericModConfigMenu
                 Texture2D tex = this.Helper.GameContent.Load<Texture2D>(AssetManager.ConfigButton);
                 this.ConfigButton = new Button(tex)
                 {
-                    LocalPosition = new Vector2(36, Game1.viewport.Height - 100),
+                    LocalPosition = new Vector2(36, Game1.uiViewport.Height - 100),
                     Callback = _ =>
                     {
                         Game1.playSound("newArtifact");
@@ -280,7 +286,7 @@ namespace GenericModConfigMenu
             {
                 // Gamepad support
                 Texture2D tex = this.Helper.GameContent.Load<Texture2D>(AssetManager.ConfigButton);
-                ClickableComponent button = new(new(0, Game1.viewport.Height - 100, tex.Width / 2, tex.Height / 2), "GMCM") // Why /2? Who knows
+                ClickableComponent button = new(new(0, Game1.uiViewport.Height - 100, tex.Width / 2, tex.Height / 2), "GMCM") // Why /2? Who knows
                 {
                     myID = 509800,
                     rightNeighborID = tm.buttons[0].myID,
@@ -315,7 +321,7 @@ namespace GenericModConfigMenu
 
             configMenu.Register(
                 mod: this.ModManifest,
-                reset: () => this.Config = new OwnModConfig(),
+                reset: () => { this.Config = new OwnModConfig(); TableNavigator.Enabled = this.Config.SnapNavigation; },
                 save: () => this.Helper.WriteConfig(this.Config),
                 titleScreenOnly: false
             );
@@ -338,6 +344,21 @@ namespace GenericModConfigMenu
                 getValue: () => this.Config.OpenMenuKey,
                 setValue: value => this.Config.OpenMenuKey = value
             );
+
+            configMenu.AddBoolOption(
+                mod: this.ModManifest,
+                name: I18n.Options_SnapNavigation_Name,
+                tooltip: I18n.Options_SnapNavigation_Desc,
+                getValue: () => this.Config.SnapNavigation,
+                setValue: value =>
+                {
+                    this.Config.SnapNavigation = value;
+                    TableNavigator.Enabled = value;
+                }
+            );
+
+            // Sync static flag from config on startup
+            TableNavigator.Enabled = this.Config.SnapNavigation;
 
             var BetterGameMenu = this.Helper.ModRegistry.GetApi<IBetterGameMenuApi>("leclair.bettergamemenu");
             BetterGameMenu?.OnTabContextMenu(evt =>
@@ -371,7 +392,15 @@ namespace GenericModConfigMenu
             if (this.IsTitleMenuInteractable())
             {
                 SetupTitleMenuButton();
-                this.Ui?.Update();
+
+                // Update in UI mode so hover detection uses uiViewport coordinates
+                // (SMAPI's GenericModConfigFix redirects OnRendered to draw during
+                // RenderSteps.Menu which runs inside PushUIMode)
+                Game1.PushUIMode();
+                try { this.Ui?.Update(); }
+                finally { Game1.PopUIMode(); }
+
+
             }
 
             if (wasConfigMenu && TitleMenu.subMenu == null)
@@ -389,7 +418,7 @@ namespace GenericModConfigMenu
         private void OnWindowResized(object sender, WindowResizedEventArgs e)
         {
             if ( this.ConfigButton != null )
-                this.ConfigButton.LocalPosition = new Vector2(this.ConfigButton.Position.X, Game1.viewport.Height - 100);
+                this.ConfigButton.LocalPosition = new Vector2(this.ConfigButton.Position.X, Game1.uiViewport.Height - 100);
         }
 
         /// <inheritdoc cref="IDisplayEvents.Rendered"/>

--- a/framework/GenericModConfigMenu/i18n/default.json
+++ b/framework/GenericModConfigMenu/i18n/default.json
@@ -31,6 +31,8 @@
     "options.open-menu-key.desc": "A keybind which opens the menu.",
     "options.scroll-speed.name": "Scroll speed",
     "options.scroll-speed.desc": "The number of field rows to offset when scrolling a config menu.",
+    "options.snap-navigation.name": "Snap navigation",
+    "options.snap-navigation.desc": "Enable D-pad and thumbstick snap navigation in config menus when using a controller. Disable to use the free cursor instead.",
 
      //Search Box
     "list.search-label": "Search:",

--- a/shared/SpaceShared/UI/Dropdown.cs
+++ b/shared/SpaceShared/UI/Dropdown.cs
@@ -49,6 +49,9 @@ namespace SpaceShared.UI
         public static Dropdown ActiveDropdown;
         public static int SinceDropdownWasActive = 0;
 
+        /// <summary>Set by TableNavigator when gamepad changes ActiveChoice. Prevents mouse hit-test from overwriting the selection for one frame.</summary>
+        public bool GamepadNavigated;
+
         /// <inheritdoc />
         public override int Width => Math.Max(300, Math.Min(500, this.RequestWidth));
 
@@ -106,7 +109,11 @@ namespace SpaceShared.UI
                 int tall = Math.Min(this.MaxValuesAtOnce, this.Choices.Length - this.ActivePosition) * this.Height;
                 int drawY = Math.Min((int)this.Position.Y, Game1.uiViewport.Height - tall);
                 var bounds2 = new Rectangle((int)this.Position.X, drawY, this.Width, this.Height * this.MaxValuesAtOnce);
-                if (bounds2.Contains(Game1.getOldMouseX(), Game1.getOldMouseY()))
+                if (this.GamepadNavigated)
+                {
+                    this.GamepadNavigated = false;
+                }
+                else if (bounds2.Contains(Game1.getOldMouseX(), Game1.getOldMouseY()))
                 {
                     int choice = (Game1.getOldMouseY() - drawY) / this.Height;
                     this.ActiveChoice = choice + this.ActivePosition;

--- a/shared/SpaceShared/UI/Table.cs
+++ b/shared/SpaceShared/UI/Table.cs
@@ -54,6 +54,9 @@ namespace SpaceShared.UI
 
         public int RowCount => this.Rows.Count;
 
+        /// <summary>Read-only access to row data for navigation.</summary>
+        public IReadOnlyList<Element[]> RowData => this.Rows;
+
         public Scrollbar Scrollbar { get; }
 
         /// <inheritdoc />

--- a/shared/SpaceShared/UI/TableNavigator.cs
+++ b/shared/SpaceShared/UI/TableNavigator.cs
@@ -483,6 +483,11 @@ namespace SpaceShared.UI
             if (this.OpenDropdown == null)
                 return;
 
+            // Prevent Dropdown.Update() mouse hit-test from overwriting our selection every frame.
+            // Without this, the hit-test runs on frames between D-pad presses and can pick a
+            // different choice based on stale getOldMouseY(), causing cursor flicker.
+            this.OpenDropdown.GamepadNavigated = true;
+
             int selected = this.OpenDropdown.ActiveChoice;
             int activePos = this.OpenDropdown.ActivePosition;
             int itemHeight = this.OpenDropdown.Height;

--- a/shared/SpaceShared/UI/TableNavigator.cs
+++ b/shared/SpaceShared/UI/TableNavigator.cs
@@ -1,0 +1,535 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using StardewValley;
+
+#if IS_SPACECORE
+namespace SpaceCore.UI
+{
+    public
+#else
+namespace SpaceShared.UI
+{
+    internal
+#endif
+         class TableNavigator
+    {
+        /*********
+        ** Fields
+        *********/
+        private readonly Table Table;
+        private int FocusedRow = -1;
+        private List<int> InteractiveRows;
+        private bool NeedsRebuild = true;
+
+        /// <summary>Previous gamepad state for edge detection.</summary>
+        private GamePadState PrevPad;
+
+        // Stick navigation hold-to-repeat
+        private int StickDir;
+        private int StickTick;
+        private bool StickInitial;
+        private const float StickThreshold = 0.3f;
+        private const int InitialDelay = 18; // ~300ms at 60fps
+        private const int RepeatDelay = 9;   // ~150ms at 60fps
+
+        // Dropdown navigation state
+        private Dropdown OpenDropdown;
+        private int DropdownOriginalChoice;
+
+        // Bottom button navigation (Cancel, Reset, Save, Save&Close)
+        private int FocusedButton = -1; // -1 = focus is in table, 0+ = index into BottomButtons
+        private bool FocusOnButtons => this.FocusedButton >= 0;
+
+
+        /*********
+        ** Accessors
+        *********/
+        /// <summary>When false, snap navigation is completely disabled regardless of gamepad setting.</summary>
+        public static bool Enabled { get; set; } = true;
+
+        /// <summary>Called when B is pressed outside a dropdown. Menu should go back/close.</summary>
+        public Action OnBack { get; set; }
+
+        /// <summary>Bottom action buttons (Cancel, Reset, Save, Save&Close). Set by the menu.</summary>
+        public Label[] BottomButtons { get; set; }
+
+        /// <summary>Get or set the currently focused row index (for save/restore across menu transitions).</summary>
+        public int CurrentFocusedRow
+        {
+            get => this.FocusedRow;
+            set => this.FocusedRow = value;
+        }
+
+
+        /*********
+        ** Public methods
+        *********/
+        public TableNavigator(Table table)
+        {
+            this.Table = table;
+            // Initialize PrevPad to current state so a freshly created navigator
+            // doesn't see phantom button edges (e.g. B held from previous menu).
+            this.PrevPad = Game1.input.GetGamePadState();
+        }
+
+        /// <summary>Mark the interactive rows list as stale (call after Table rows change).</summary>
+        public void InvalidateRows()
+        {
+            this.NeedsRebuild = true;
+        }
+
+        /// <summary>Process gamepad input. Call BEFORE Ui.Update() in menu.update().</summary>
+        public void HandleInput()
+        {
+            if (!Enabled || !Game1.options.gamepadControls)
+                return;
+
+            if (this.NeedsRebuild)
+                this.RebuildInteractiveRows();
+
+            if (this.InteractiveRows.Count == 0 && (this.BottomButtons == null || this.BottomButtons.Length == 0))
+                return;
+
+            var pad = Game1.input.GetGamePadState();
+
+            // Initialize focus on first interactive row if not set
+            if (!this.FocusOnButtons && (this.FocusedRow < 0 || !this.InteractiveRows.Contains(this.FocusedRow)))
+            {
+                if (this.InteractiveRows.Count > 0)
+                    this.FocusedRow = this.InteractiveRows[0];
+            }
+
+            // Track dropdown state from the Dropdown class's static field
+            if (Dropdown.ActiveDropdown != null && this.OpenDropdown == null)
+            {
+                this.OpenDropdown = Dropdown.ActiveDropdown;
+                this.DropdownOriginalChoice = this.OpenDropdown.ActiveChoice;
+            }
+            else if (Dropdown.ActiveDropdown == null && this.OpenDropdown != null)
+            {
+                this.OpenDropdown = null;
+            }
+
+            this.HandleUpDown(pad);
+            this.HandleLeftRight(pad);
+            this.HandleB(pad);
+
+            this.PrevPad = pad;
+        }
+
+        /// <summary>Snap cursor and ensure scroll position. Call AFTER Ui.Update() so element positions are fresh.</summary>
+        public void SnapAndScroll()
+        {
+            if (!Enabled || !Game1.options.gamepadControls)
+                return;
+
+            if (this.FocusOnButtons)
+            {
+                this.SnapCursorToButton();
+            }
+            else
+            {
+                this.EnsureFocusedVisible();
+                if (this.OpenDropdown != null)
+                    this.SnapCursorToDropdownItem();
+                else
+                    this.SnapCursorToFocused();
+            }
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+        private void RebuildInteractiveRows()
+        {
+            this.InteractiveRows = new List<int>();
+            var rows = this.Table.RowData;
+            for (int i = 0; i < rows.Count; i++)
+            {
+                if (IsRowInteractive(rows[i]))
+                    this.InteractiveRows.Add(i);
+            }
+            this.NeedsRebuild = false;
+        }
+
+        private static bool IsRowInteractive(Element[] row)
+        {
+            foreach (var el in row)
+            {
+                if (el is Checkbox) return true;
+                if (el is Slider) return true;
+                if (el is Dropdown) return true;
+                if (el is Label label && label.Callback != null) return true;
+            }
+            return false;
+        }
+
+        /// <summary>Get the element to snap the cursor to in a row.</summary>
+        private static Element GetSnapTarget(Element[] row)
+        {
+            // Prefer non-label interactive elements (checkbox, slider, dropdown)
+            foreach (var el in row)
+            {
+                if (el is Checkbox || el is Slider || el is Dropdown)
+                    return el;
+            }
+            // Fall back to label with callback (mod name, page link, button)
+            foreach (var el in row)
+            {
+                if (el is Label label && label.Callback != null)
+                    return el;
+            }
+            return row.Length > 0 ? row[0] : null;
+        }
+
+        /// <summary>Find the position of the current focused row in the interactive rows list.</summary>
+        private int FindCurrentPosition()
+        {
+            return this.InteractiveRows.IndexOf(this.FocusedRow);
+        }
+
+        private void HandleUpDown(GamePadState pad)
+        {
+            // D-pad edge detection
+            bool dpadUp = pad.DPad.Up == ButtonState.Pressed && this.PrevPad.DPad.Up == ButtonState.Released;
+            bool dpadDown = pad.DPad.Down == ButtonState.Pressed && this.PrevPad.DPad.Down == ButtonState.Released;
+
+            // Left stick or right stick discrete navigation with hold-to-repeat
+            // (Right stick also drives row navigation to prevent bounce from direct scroll handlers)
+            float lsY = Math.Abs(pad.ThumbSticks.Left.Y) >= Math.Abs(pad.ThumbSticks.Right.Y)
+                ? pad.ThumbSticks.Left.Y
+                : pad.ThumbSticks.Right.Y;
+            int newStickDir = 0;
+            if (lsY > StickThreshold) newStickDir = 1;       // Up
+            else if (lsY < -StickThreshold) newStickDir = 2; // Down
+
+            bool stickUp = false, stickDown = false;
+            if (newStickDir == 0)
+            {
+                this.StickDir = 0;
+                this.StickInitial = true;
+            }
+            else if (newStickDir != this.StickDir)
+            {
+                this.StickDir = newStickDir;
+                this.StickTick = Game1.ticks;
+                this.StickInitial = true;
+                stickUp = newStickDir == 1;
+                stickDown = newStickDir == 2;
+            }
+            else
+            {
+                int elapsed = Game1.ticks - this.StickTick;
+                int delay = this.StickInitial ? InitialDelay : RepeatDelay;
+                if (elapsed >= delay)
+                {
+                    this.StickTick = Game1.ticks;
+                    this.StickInitial = false;
+                    stickUp = newStickDir == 1;
+                    stickDown = newStickDir == 2;
+                }
+            }
+
+            bool goUp = dpadUp || stickUp;
+            bool goDown = dpadDown || stickDown;
+            if (!goUp && !goDown)
+                return;
+
+            // Dropdown navigation
+            if (this.OpenDropdown != null)
+            {
+                int count = this.OpenDropdown.Choices.Length;
+                if (count <= 0)
+                    return;
+
+                if (goUp)
+                    this.OpenDropdown.ActiveChoice = (this.OpenDropdown.ActiveChoice - 1 + count) % count;
+                else
+                    this.OpenDropdown.ActiveChoice = (this.OpenDropdown.ActiveChoice + 1) % count;
+
+                // Scroll the visible window to keep the selection visible
+                int maxVis = this.OpenDropdown.MaxValuesAtOnce;
+                if (this.OpenDropdown.ActiveChoice < this.OpenDropdown.ActivePosition)
+                    this.OpenDropdown.ActivePosition = this.OpenDropdown.ActiveChoice;
+                else if (this.OpenDropdown.ActiveChoice >= this.OpenDropdown.ActivePosition + maxVis)
+                    this.OpenDropdown.ActivePosition = this.OpenDropdown.ActiveChoice - maxVis + 1;
+
+                // Prevent Dropdown.Update() from overwriting our selection via mouse hit-test
+                this.OpenDropdown.GamepadNavigated = true;
+
+                this.OpenDropdown.Callback?.Invoke(this.OpenDropdown);
+                Game1.playSound("shiny4");
+                return;
+            }
+
+            bool hasButtons = this.BottomButtons != null && this.BottomButtons.Length > 0;
+
+            // Navigation when focus is on bottom buttons
+            if (this.FocusOnButtons)
+            {
+                if (goUp)
+                {
+                    // Move back to last table row
+                    this.FocusedButton = -1;
+                    if (this.InteractiveRows.Count > 0)
+                        this.FocusedRow = this.InteractiveRows[this.InteractiveRows.Count - 1];
+                    Game1.playSound("shiny4");
+                }
+                // Down on buttons does nothing (or could wrap to top)
+                return;
+            }
+
+            // Navigation within table rows
+            int pos = this.FindCurrentPosition();
+            if (goUp)
+            {
+                if (pos <= 0)
+                {
+                    // At top of table — wrap to bottom buttons if available, else wrap to last row
+                    if (hasButtons)
+                    {
+                        this.FocusedButton = 0;
+                        Game1.playSound("shiny4");
+                        return;
+                    }
+                    else
+                    {
+                        this.FocusedRow = this.InteractiveRows[this.InteractiveRows.Count - 1];
+                    }
+                }
+                else
+                {
+                    this.FocusedRow = this.InteractiveRows[pos - 1];
+                }
+            }
+            else // goDown
+            {
+                if (pos < 0 || pos >= this.InteractiveRows.Count - 1)
+                {
+                    // At bottom of table — move to bottom buttons if available, else wrap to first row
+                    if (hasButtons)
+                    {
+                        this.FocusedButton = 0;
+                        Game1.playSound("shiny4");
+                        return;
+                    }
+                    else
+                    {
+                        this.FocusedRow = this.InteractiveRows[0];
+                    }
+                }
+                else
+                {
+                    this.FocusedRow = this.InteractiveRows[pos + 1];
+                }
+            }
+
+            Game1.playSound("shiny4");
+        }
+
+        private void HandleLeftRight(GamePadState pad)
+        {
+            // D-pad edge detection
+            bool dpadLeft = pad.DPad.Left == ButtonState.Pressed && this.PrevPad.DPad.Left == ButtonState.Released;
+            bool dpadRight = pad.DPad.Right == ButtonState.Pressed && this.PrevPad.DPad.Right == ButtonState.Released;
+
+            // Left stick horizontal (edge-only)
+            float lsX = pad.ThumbSticks.Left.X;
+            bool stickLeft = false, stickRight = false;
+            if (Math.Abs(lsX) > StickThreshold && Math.Abs(lsX) > Math.Abs(pad.ThumbSticks.Left.Y))
+            {
+                if (Math.Abs(this.PrevPad.ThumbSticks.Left.X) <= StickThreshold)
+                {
+                    stickLeft = lsX < 0;
+                    stickRight = lsX > 0;
+                }
+            }
+
+            bool goLeft = dpadLeft || stickLeft;
+            bool goRight = dpadRight || stickRight;
+            if (!goLeft && !goRight)
+                return;
+
+            // Navigate between bottom buttons with Left/Right
+            if (this.FocusOnButtons && this.BottomButtons != null)
+            {
+                int count = this.BottomButtons.Length;
+                if (goRight)
+                    this.FocusedButton = Math.Min(this.FocusedButton + 1, count - 1);
+                else
+                    this.FocusedButton = Math.Max(this.FocusedButton - 1, 0);
+                Game1.playSound("shiny4");
+                return;
+            }
+
+            if (this.OpenDropdown != null)
+                return; // Left/Right does nothing in dropdown mode
+
+            if (this.FocusedRow < 0 || this.FocusedRow >= this.Table.RowData.Count)
+                return;
+
+            var target = GetSnapTarget(this.Table.RowData[this.FocusedRow]);
+            if (target == null)
+                return;
+
+            // Slider: adjust value
+            if (target is Slider<int> intSlider)
+            {
+                int step = intSlider.Interval;
+                int newVal = goRight
+                    ? Math.Min(intSlider.Value + step, intSlider.Maximum)
+                    : Math.Max(intSlider.Value - step, intSlider.Minimum);
+                if (newVal != intSlider.Value)
+                {
+                    intSlider.Value = newVal;
+                    intSlider.Callback?.Invoke(intSlider);
+                    Game1.playSound("smallSelect");
+                }
+                return;
+            }
+
+            if (target is Slider<float> floatSlider)
+            {
+                float step = floatSlider.Interval;
+                float newVal = goRight
+                    ? Math.Min(floatSlider.Value + step, floatSlider.Maximum)
+                    : Math.Max(floatSlider.Value - step, floatSlider.Minimum);
+                if (Math.Abs(newVal - floatSlider.Value) > 0.0001f)
+                {
+                    floatSlider.Value = newVal;
+                    floatSlider.Callback?.Invoke(floatSlider);
+                    Game1.playSound("smallSelect");
+                }
+                return;
+            }
+        }
+
+        private void HandleB(GamePadState pad)
+        {
+            bool bPressed = pad.Buttons.B == ButtonState.Pressed && this.PrevPad.Buttons.B == ButtonState.Released;
+            if (!bPressed)
+                return;
+
+            if (this.OpenDropdown != null)
+            {
+                // Cancel dropdown — revert to original choice
+                this.OpenDropdown.ActiveChoice = this.DropdownOriginalChoice;
+                this.OpenDropdown.Callback?.Invoke(this.OpenDropdown);
+                this.OpenDropdown.Dropped = false;
+                if (this.OpenDropdown.Parent?.RenderLast == this.OpenDropdown)
+                    this.OpenDropdown.Parent.RenderLast = null;
+                Dropdown.ActiveDropdown = null;
+                this.OpenDropdown = null;
+                Game1.playSound("bigDeSelect");
+                return;
+            }
+
+            // If on buttons, move back to table
+            if (this.FocusOnButtons)
+            {
+                this.FocusedButton = -1;
+                Game1.playSound("bigDeSelect");
+                return;
+            }
+
+            this.OnBack?.Invoke();
+        }
+
+        private void SnapCursorToFocused()
+        {
+            if (this.FocusedRow < 0 || this.FocusedRow >= this.Table.RowData.Count)
+                return;
+
+            var target = GetSnapTarget(this.Table.RowData[this.FocusedRow]);
+            if (target == null)
+                return;
+
+            var bounds = target.Bounds;
+            Game1.setMousePosition(bounds.Center.X, bounds.Center.Y);
+        }
+
+        private void SnapCursorToButton()
+        {
+            if (this.BottomButtons == null || this.FocusedButton < 0 || this.FocusedButton >= this.BottomButtons.Length)
+                return;
+
+            var btn = this.BottomButtons[this.FocusedButton];
+            if (btn.IsHidden())
+            {
+                // Skip hidden buttons (e.g., Reset hidden on sub-pages)
+                // Try to move to next visible button
+                for (int i = 0; i < this.BottomButtons.Length; i++)
+                {
+                    if (!this.BottomButtons[i].IsHidden())
+                    {
+                        this.FocusedButton = i;
+                        btn = this.BottomButtons[i];
+                        break;
+                    }
+                }
+                if (btn.IsHidden())
+                    return;
+            }
+
+            var bounds = btn.Bounds;
+            Game1.setMousePosition(bounds.Center.X, bounds.Center.Y);
+        }
+
+        private void SnapCursorToDropdownItem()
+        {
+            if (this.OpenDropdown == null)
+                return;
+
+            int selected = this.OpenDropdown.ActiveChoice;
+            int activePos = this.OpenDropdown.ActivePosition;
+            int itemHeight = this.OpenDropdown.Height;
+
+            int tall = Math.Min(this.OpenDropdown.MaxValuesAtOnce, this.OpenDropdown.Choices.Length - activePos) * itemHeight;
+            int drawY = Math.Min((int)this.OpenDropdown.Position.Y, Game1.uiViewport.Height - tall);
+
+            int itemIndex = selected - activePos;
+            if (itemIndex >= 0 && itemIndex < this.OpenDropdown.MaxValuesAtOnce)
+            {
+                int itemY = drawY + itemIndex * itemHeight + itemHeight / 2;
+                int itemX = (int)this.OpenDropdown.Position.X + this.OpenDropdown.Width / 2;
+                Game1.setMousePosition(itemX, itemY);
+            }
+        }
+
+        private void EnsureFocusedVisible()
+        {
+            if (this.FocusOnButtons || this.FocusedRow < 0)
+                return;
+
+            var rows = this.Table.RowData;
+            if (this.FocusedRow >= rows.Count)
+                return;
+
+            var target = GetSnapTarget(rows[this.FocusedRow]);
+            if (target == null)
+                return;
+
+            // Element positions are now fresh (called after Ui.Update/Table.Update)
+            float tableTop = this.Table.Position.Y;
+            float tableBottom = tableTop + this.Table.Height;
+            float elementTop = target.Position.Y;
+            float elementBottom = elementTop + target.Height;
+
+            if (elementTop < tableTop)
+            {
+                // Element above visible area — scroll up by the right amount
+                int rowsNeeded = (int)Math.Ceiling((tableTop - elementTop) / this.Table.RowHeight);
+                this.Table.Scrollbar.ScrollBy(-rowsNeeded);
+            }
+            else if (elementBottom > tableBottom)
+            {
+                // Element below visible area — scroll down by the right amount
+                int rowsNeeded = (int)Math.Ceiling((elementBottom - tableBottom) / this.Table.RowHeight);
+                this.Table.Scrollbar.ScrollBy(rowsNeeded);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds D-pad/thumbstick snap navigation for controller users in GMCM config menus, as discussed in #560.

- **D-pad/left stick** navigates between interactive options (with hold-to-repeat)
- **D-pad left/right** adjusts sliders
- **D-pad up/down inside dropdowns** cycles choices
- **A button** clicks focused elements (checkboxes, buttons, dropdowns)
- **B button** navigates back (dropdown → table → mod list → close)
- **Bottom buttons** (Cancel/Reset/Save/Save&Close) reachable via D-pad
- **"Snap navigation" toggle** in GMCM's own settings — users can disable to fall back to free cursor
- Only activates when `Game1.options.gamepadControls` is true AND the toggle is enabled
- **Mouse/keyboard behavior completely unaffected**
- **Dropdown flicker fix**: `SnapCursorToDropdownItem()` sets `GamepadNavigated = true` every frame while open, preventing `Dropdown.Update()` mouse hit-test from fighting with the gamepad selection

Also removes the Android-only skips for `SButton`/`KeybindList` keybind options (they now display on all platforms) and enables tooltips on Android.

### Key files

| File | Change |
|------|--------|
| `shared/SpaceShared/UI/TableNavigator.cs` | **New** — snap navigation engine (540 lines) |
| `shared/SpaceShared/UI/Table.cs` | Add `RowData` property for navigator access |
| `shared/SpaceShared/UI/Dropdown.cs` | Add `GamepadNavigated` flag to prevent mouse overwrite |
| `framework/GenericModConfigMenu/Framework/OwnModConfig.cs` | Add `SnapNavigation` setting |
| `framework/GenericModConfigMenu/Mod.cs` | Config toggle, focus restoration, viewport fixes |
| `framework/GenericModConfigMenu/Framework/ModConfigMenu.cs` | Navigator integration |
| `framework/GenericModConfigMenu/Framework/SpecificModConfigMenu.cs` | Navigator integration |
| `framework/GenericModConfigMenu/i18n/default.json` | Translation strings |

## Test plan

- [x] PC with Xbox controller — snap navigation works in mod list and mod config pages
- [x] PC with mouse — no behavior changes, mouse works normally
- [x] Snap navigation toggle appears in GMCM's own settings
- [x] Toggle persists across sessions (saved to config.json)
- [x] B button back-navigation: dropdown → table → mod list → close
- [x] Slider adjustment with D-pad left/right
- [x] Dropdown navigation with D-pad up/down
- [x] Bottom buttons reachable and navigable
- [x] Android devices (Ayaneo Pocket Air Mini, Odin Pro)
- [x] Dropdown cursor flicker fixed — no more flickering between gamepad and mouse selections

🤖 Generated with [Claude Code](https://claude.com/claude-code)