### PR TITLE
Only do immediate perk if the profession is actually added

### DIFF
--- a/framework/SpaceCore/Interface/SkillLevelUpMenu.cs
+++ b/framework/SpaceCore/Interface/SkillLevelUpMenu.cs
@@ -632,8 +632,10 @@ namespace SpaceCore.Interface
                                 this.leftProfessionColor = Color.Green;
                                 if (Game1.didPlayerJustLeftClick() && this.readyToClose())
                                 {
-                                    Game1.player.professions.Add(this.professionsToChoose[0]);
-                                    this.getImmediateProfessionPerk(this.professionsToChoose[0]);
+                                    if (Game1.player.professions.Add(this.professionsToChoose[0]))
+                                    {
+                                        this.getImmediateProfessionPerk(this.professionsToChoose[0]);
+                                    }
                                     this.isActive = false;
                                     this.informationUp = false;
                                     this.isProfessionChooser = false;
@@ -644,8 +646,10 @@ namespace SpaceCore.Interface
                                 this.rightProfessionColor = Color.Green;
                                 if (Game1.didPlayerJustLeftClick() && this.readyToClose())
                                 {
-                                    Game1.player.professions.Add(this.professionsToChoose[1]);
-                                    this.getImmediateProfessionPerk(this.professionsToChoose[1]);
+                                    if (Game1.player.professions.Add(this.professionsToChoose[1]))
+                                    {
+                                        this.getImmediateProfessionPerk(this.professionsToChoose[1]);
+                                    }
                                     this.isActive = false;
                                     this.informationUp = false;
                                     this.isProfessionChooser = false;


### PR DESCRIPTION
Tiny check to make sure immediate perks aren't repeated if another mod has already added the profession through other methods.

Professions are only added once, so information about multiple counts would be lost and unavailable when undoing immediate perks.