### PR TITLE
fix the unpatch logic for save serializer

### DIFF
--- a/framework/SpaceCore/Patches/SaveGamePatcher.cs
+++ b/framework/SpaceCore/Patches/SaveGamePatcher.cs
@@ -33,6 +33,7 @@ namespace SpaceCore.Patches
         *********/
         /// <summary>Manages the custom save serialization.</summary>
         internal static SerializerManager SerializerManager;
+        internal static List<(MethodBase, HarmonyPatchType)> OtherPatchedMethods = [];
 
 
         /*********
@@ -48,25 +49,41 @@ namespace SpaceCore.Patches
         /// <inheritdoc />
         public override void Apply(Harmony harmony, IMonitor monitor)
         {
-            harmony.Patch(
-                original: AccessTools.Method(typeof(SaveSerializer), nameof(SaveSerializer.GetSerializer)),
-                prefix: this.GetHarmonyMethod(nameof(Before_GetSerializer))
-            );
+            {
+                MethodBase original = AccessTools.Method(typeof(SaveSerializer), nameof(SaveSerializer.GetSerializer));
+                harmony.Patch(
+                    original: original,
+                    prefix: this.GetHarmonyMethod(nameof(Before_GetSerializer))
+                );
+                OtherPatchedMethods.Add((original, HarmonyPatchType.Prefix));
+            }
 
-            harmony.Patch(
-                original: this.RequireMethod<SaveGame>(nameof(SaveGame.Load)),
-                prefix: this.GetHarmonyMethod(nameof(Before_Load), priority: Priority.First)
-            );
+            {
+                MethodBase original = this.RequireMethod<SaveGame>(nameof(SaveGame.Load));
+                harmony.Patch(
+                    original: original,
+                    prefix: this.GetHarmonyMethod(nameof(Before_Load), priority: Priority.First)
+                );
+                OtherPatchedMethods.Add((original, HarmonyPatchType.Prefix));
+            }
 
-            harmony.Patch(
-                original: this.RequireMethod<SaveGameMenu>(nameof(SaveGameMenu.update)),
-                transpiler: this.GetHarmonyMethod(nameof(Transpile_SaveGameMenuUpdate))
-            );
+            {
+                MethodBase original = this.RequireMethod<SaveGameMenu>(nameof(SaveGameMenu.update));
+                harmony.Patch(
+                    original: original,
+                    transpiler: this.GetHarmonyMethod(nameof(Transpile_SaveGameMenuUpdate))
+                );
+                OtherPatchedMethods.Add((original, HarmonyPatchType.Transpiler));
+            }
 
-            harmony.Patch(
-                original: this.RequireMethod<SaveGame>(nameof(SaveGame.loadDataToLocations)),
-                prefix: this.GetHarmonyMethod(nameof(Before_LoadDataToLocations))
-            );
+            {
+                MethodBase original = this.RequireMethod<SaveGame>(nameof(SaveGame.loadDataToLocations));
+                harmony.Patch(
+                    original: original,
+                    prefix: this.GetHarmonyMethod(nameof(Before_LoadDataToLocations))
+                );
+                OtherPatchedMethods.Add((original, HarmonyPatchType.Prefix));
+            }
 
             foreach (var method in SaveGamePatcher.GetLoadEnumeratorMethods())
             {
@@ -109,7 +126,7 @@ namespace SpaceCore.Patches
                     }
                 }
             }
-            foreach (var meth in typeof(LoadGameMenu).GetMethods(BindingFlags.Public|BindingFlags.NonPublic|BindingFlags.Static))
+            foreach (var meth in typeof(LoadGameMenu).GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
             {
                 if (meth.Name.Contains("<FindSaveGames>") && (meth.Name.Contains("TryReadSaveData") || meth.Name.Contains("TryReadSaveInfo")))
                 {
@@ -441,7 +458,7 @@ namespace SpaceCore.Patches
 
             foreach (var insn in insns)
             {
-                if ( insn.operand is MethodInfo meth && meth == AccessTools.Method( typeof(SaveSerializer), nameof(SaveSerializer.GetSerializer ) ) )
+                if (insn.operand is MethodInfo meth && meth == AccessTools.Method(typeof(SaveSerializer), nameof(SaveSerializer.GetSerializer)))
                 {
                     insn.operand = AccessTools.Method(typeof(RedirectGetSerializerForNonWindowsPatch1), nameof(RedirectGetSerializerForNonWindowsPatch1.GetSerializerProxy));
                 }

--- a/framework/SpaceCore/SpaceCore.cs
+++ b/framework/SpaceCore/SpaceCore.cs
@@ -142,7 +142,7 @@ namespace SpaceCore
         private LegacyDataMigrator LegacyDataMigrator = null!;
 
         /// <summary>Whether the current update tick is the first one raised by SMAPI.</summary>
-        private bool IsFirstTick;
+        private bool IsFirstTick = true;
 
         internal class EquipmentSlotData
         {
@@ -1241,15 +1241,20 @@ namespace SpaceCore
             }
 
             // disable serializer if not used
-            if (this.IsFirstTick && SpaceCore.ModTypes.Count == 0)
+            if (this.IsFirstTick)
             {
                 this.IsFirstTick = false;
 
-                Log.Info("Disabling serializer patches (no mods using serializer API)");
-                foreach (var method in SaveGamePatcher.GetSaveEnumeratorMethods())
-                    this.Harmony.Unpatch(method, PatchHelper.RequireMethod<SaveGamePatcher>(nameof(SaveGamePatcher.Transpile_GetSaveEnumerator)));
-                foreach (var method in SaveGamePatcher.GetLoadEnumeratorMethods())
-                    this.Harmony.Unpatch(method, PatchHelper.RequireMethod<SaveGamePatcher>(nameof(SaveGamePatcher.Transpile_GetLoadEnumerator)));
+                if (SpaceCore.ModTypes.Count == 0)
+                {
+                    Log.Info("Disabling serializer patches (no mods using serializer API)");
+                    foreach (var method in SaveGamePatcher.GetSaveEnumeratorMethods())
+                        this.Harmony.Unpatch(method, PatchHelper.RequireMethod<SaveGamePatcher>(nameof(SaveGamePatcher.Transpile_GetSaveEnumerator)));
+                    foreach (var method in SaveGamePatcher.GetLoadEnumeratorMethods())
+                        this.Harmony.Unpatch(method, PatchHelper.RequireMethod<SaveGamePatcher>(nameof(SaveGamePatcher.Transpile_GetLoadEnumerator)));
+                    foreach ((MethodBase original, HarmonyPatchType type) in SaveGamePatcher.OtherPatchedMethods)
+                        this.Harmony.Unpatch(original, type, harmonyID: this.Harmony.Id);
+                }
             }
         }
 


### PR DESCRIPTION
Although this is more correct it is also useless right now because spacecore always registers the modded type `SpaceCore.Dungeons.SetPieceNetData`.